### PR TITLE
Bugfix - catch invalid phone exception

### DIFF
--- a/sdk/src/main/java/com/xing/android/sdk/json/user/XingAddressMapper.java
+++ b/sdk/src/main/java/com/xing/android/sdk/json/user/XingAddressMapper.java
@@ -20,10 +20,14 @@
  * THE SOFTWARE.
  */
 
-package com.xing.android.sdk.json.user;import android.util.JsonReader;
+package com.xing.android.sdk.json.user;
+
+import android.util.JsonReader;
 import android.util.JsonToken;
+import android.util.Log;
 
 import com.xing.android.sdk.model.user.XingAddress;
+import com.xing.android.sdk.model.user.XingPhone;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,93 +37,111 @@ import java.util.List;
  * Parser that gets the XingAddress from a JsonReader
  *
  * @author david.gonzalez
- * */
+ */
 public final class XingAddressMapper {
+    private final static String TAG = "XingAddressMapper";
+
     /**
      * Extracts the XingAddress out of the JsonReader
      *
      * @param reader The JsonReader containing the TimeZone
      * @return The XingAddress object
      * @throws IOException
-     * */
+     */
     public static XingAddress parseXingAddress(JsonReader reader) throws IOException {
         XingAddress xingaddress = new XingAddress();
         reader.beginObject();
-        while(reader.hasNext()) {
-            switch(reader.nextName()) {
-                case "email":{
-                    if(reader.peek() == JsonToken.NULL) {
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "email": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
                         xingaddress.setEmail(reader.nextString());
                     }
                     break;
                 }
-                case "city":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "city": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
                         xingaddress.setCity(reader.nextString());
                     }
                     break;
                 }
-                case "country":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "country": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
                         xingaddress.setCountry(reader.nextString());
                     }
                     break;
                 }
-                case "fax":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "fax": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
-                        xingaddress.setFax(reader.nextString());
+                        String rawFax = reader.nextString();
+                        try {
+                            xingaddress.setFax(rawFax);
+                        } catch (XingPhone.InvalidPhoneException e) {
+                            Log.d(TAG, rawFax + " is not a valid XING phone number");
+                        }
                     }
                     break;
                 }
-                case "mobile_phone":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "mobile_phone": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
-                        xingaddress.setMobilePhone(reader.nextString());
+                        final String rawMobilePhone = reader.nextString();
+                        try {
+                            xingaddress.setMobilePhone(rawMobilePhone);
+                        } catch (XingPhone.InvalidPhoneException e) {
+                            Log.d(TAG, rawMobilePhone + " is not a valid XING phone number");
+                        }
                     }
                     break;
                 }
-                case "phone":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "phone": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
-                        xingaddress.setPhone(reader.nextString());
+                        final String rawPhone = reader.nextString();
+                        try {
+                            xingaddress.setPhone(rawPhone);
+                        } catch (XingPhone.InvalidPhoneException e) {
+                            Log.d(TAG, rawPhone + " is not a valid XING phone number");
+                        }
                     }
                     break;
                 }
-                case "province":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "province": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
                         xingaddress.setProvince(reader.nextString());
                     }
                     break;
                 }
-                case "street":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "street": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
                         xingaddress.setStreet(reader.nextString());
                     }
                     break;
                 }
-                case "zip_code":{
-                    if(reader.peek() == JsonToken.NULL) {
+                case "zip_code": {
+                    if (reader.peek() == JsonToken.NULL) {
                         reader.nextNull();
                     } else {
                         xingaddress.setZipCode(reader.nextString());
                     }
                     break;
                 }
-                default: reader.skipValue();
+                default:
+                    reader.skipValue();
             }
         }
         reader.endObject();
@@ -132,11 +154,11 @@ public final class XingAddressMapper {
      * @param reader The JsonReader
      * @return A list with TimeZone objects
      * @throws IOException
-     * */
-    public static List<XingAddress> parseXingAddressList (JsonReader reader) throws IOException {
+     */
+    public static List<XingAddress> parseXingAddressList(JsonReader reader) throws IOException {
         List<XingAddress> xingAddressList = new ArrayList<>(0);
         reader.beginArray();
-        while(reader.hasNext()) {
+        while (reader.hasNext()) {
             xingAddressList.add(parseXingAddress(reader));
         }
         reader.endArray();

--- a/sdk/src/test/java/com/xing/android/sdk/json/user/XingAddressMapperTest.java
+++ b/sdk/src/test/java/com/xing/android/sdk/json/user/XingAddressMapperTest.java
@@ -77,6 +77,48 @@ public class XingAddressMapperTest extends ParserUnitTestBase {
             TEST_ADDRESS_1 + ", " +
             TEST_ADDRESS_2 + "]";
 
+    private static final String TEST_ADDRESS_INVALID_PHONE_1 = "{\n" +
+            "        \"city\": \"Hamburg\",\n" +
+            "        \"country\": \"DE\",\n" +
+            "        \"zip_code\": \"20357\",\n" +
+            "        \"street\": \"Privatstraße 1\",\n" +
+            "        \"phone\": \"49 40|1234560\",\n" +
+            "        \"fax\": \"12|34|54323\",\n" +
+            "        \"province\": \"Hamburg\",\n" +
+            "        \"email\": \"max@mustermann.de\",\n" +
+            "        \"mobile_phone\": \"49|0155|1234567\"\n" +
+            "      }";
+
+    private static final String TEST_ADDRESS_INVALID_PHONE_2 = "{\n" +
+            "        \"city\": \"Hamburg\",\n" +
+            "        \"country\": \"DE\",\n" +
+            "        \"zip_code\": \"20357\",\n" +
+            "        \"street\": \"Privatstraße 1\",\n" +
+            "        \"phone\": \"49||1234560\",\n" +
+            "        \"fax\": \"|123|\",\n" +
+            "        \"province\": \"Hamburg\",\n" +
+            "        \"email\": \"max@mustermann.de\",\n" +
+            "        \"mobile_phone\": \"|0155-1234567\"\n" +
+            "      }";
+
+    private static final String TEST_ADDRESS_INVALID_PHONE_3 = "{\n" +
+            "        \"city\": \"Hamburg\",\n" +
+            "        \"country\": \"DE\",\n" +
+            "        \"zip_code\": \"20357\",\n" +
+            "        \"street\": \"Privatstraße 1\",\n" +
+            "        \"phone\": \"||1234560\",\n" +
+            "        \"fax\": \"\",\n" +
+            "        \"province\": \"Hamburg\",\n" +
+            "        \"email\": \"max@mustermann.de\",\n" +
+            "        \"mobile_phone\": \"49|0155|\"\n" +
+            "      }";
+
+    private static final String TEST_INVALID_PHONE_ADDRESSES = "[" +
+            TEST_ADDRESS_INVALID_PHONE_1 + ", " +
+            TEST_ADDRESS_1 + ", " +
+            TEST_ADDRESS_INVALID_PHONE_2 + ", " +
+            TEST_ADDRESS_2 + ", " +
+            TEST_ADDRESS_INVALID_PHONE_3 + "]";
 
     @Test
     public void parseAddressWithNoFax() throws Exception {
@@ -120,5 +162,34 @@ public class XingAddressMapperTest extends ParserUnitTestBase {
         XingAddress addressFromParcel = createNewObjectViaParcelFlow(address, XingAddress.CREATOR);
         assertEquals(address.hashCode(), addressFromParcel.hashCode());
         assertEquals(address, addressFromParcel);
+    }
+
+    @Test
+    public void parseAddressInvalidPhoneNumber1() throws Exception {
+        XingAddress address = XingAddressMapper
+                .parseXingAddress(getReaderForJson(TEST_ADDRESS_INVALID_PHONE_1));
+        assertNotNull(address);
+    }
+
+    @Test
+    public void parseAddressInvalidPhoneNumber2() throws Exception {
+        XingAddress address = XingAddressMapper
+                .parseXingAddress(getReaderForJson(TEST_ADDRESS_INVALID_PHONE_2));
+        assertNotNull(address);
+    }
+
+    @Test
+    public void parseAddressInvalidPhoneNumber3() throws Exception {
+        XingAddress address = XingAddressMapper
+                .parseXingAddress(getReaderForJson(TEST_ADDRESS_INVALID_PHONE_3));
+        assertNotNull(address);
+    }
+
+    @Test
+    public void parseListOfInvalidAddresses() throws Exception {
+        List<XingAddress> addresses = XingAddressMapper
+                .parseXingAddressList(getReaderForJson(TEST_INVALID_PHONE_ADDRESSES));
+        assertNotNull(addresses);
+        assertEquals(addresses.size(), 5);
     }
 }


### PR DESCRIPTION
When parsing a user, the api might return an address with an invalid phone number. In this PR I'm catching the InvalidPhoneException otherwise the whole user parsing fails.
Here's an example of an address received from the api:
"private_address": {
"street": "Hamburger Strasse 459",
"zip_code": "20515",
"city": "Hamburg",
"province": "Hamburg",
"country": "Deutschland",
"email": "nick0815-xing-test-data@web.de",
"fax": null,
"phone": "||64222789",
"mobile_phone": null
},
...
