### PR TITLE
Hide HttpError constructors.

### DIFF
--- a/api-client/src/main/java/com/xing/api/HttpError.java
+++ b/api-client/src/main/java/com/xing/api/HttpError.java
@@ -22,12 +22,12 @@ import java.util.List;
 /**
  * Generic HTTP Error Object that maps the error response of XWS.
  *
- * This is the default object that is returned when the request is successful but there was something wrong with the
- * request.
+ * This is the default object that is returned when the request is successful but the server returned an error request.
  *
  * The API will respond to invalid requests with common HTTP status code like 401, 403 and 404. In some cases the
  * status code is ambiguous so you might not be able to tell, e.g. if the error was a missing parameter or an invalid
- * value for a parameter. In order to make sure you can react to certain errors, we provide a JSON body for (almost)
+ * value for a parameter. In order to make sure that a user can react to certain errors, we provide a JSON body for
+ * (almost)
  * all client error responses.
  *
  * @author daniel.hartwich
@@ -41,7 +41,8 @@ public class HttpError {
     @Json(name = "errors")
     private final List<Error> errors;
 
-    public HttpError(String errorName, String errorMessage, List<Error> errors) {
+    // This object is not to be instantiated outside this package.
+    HttpError(String errorName, String errorMessage, List<Error> errors) {
         this.errorName = errorName;
         this.errorMessage = errorMessage;
         this.errors = errors;
@@ -73,11 +74,11 @@ public class HttpError {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        HttpError that = (HttpError) o;
+        HttpError error = (HttpError) o;
 
-        return (errorName != null ? errorName.equals(that.errorName) : that.errorName == null)
-              && (errorMessage != null ? errorMessage.equals(that.errorMessage) : that.errorMessage == null)
-              && (errors != null ? errors.equals(that.errors) : that.errors == null);
+        return (errorName != null ? errorName.equals(error.errorName) : error.errorName == null)
+              && (errorMessage != null ? errorMessage.equals(error.errorMessage) : error.errorMessage == null)
+              && (errors != null ? errors.equals(error.errors) : error.errors == null);
     }
 
     @Override
@@ -88,13 +89,15 @@ public class HttpError {
         return result;
     }
 
+    /** Represents an error for a specific form field or query parameters, with a respective reason for the error. */
     public static final class Error {
         @Json(name = "field")
         public final String field;
         @Json(name = "reason")
         public final Reason reason;
 
-        public Error(String field, Reason reason) {
+        // This object is not to be instantiated outside this package.
+        Error(String field, Reason reason) {
             this.field = field;
             this.reason = reason;
         }
@@ -124,6 +127,7 @@ public class HttpError {
             return result;
         }
 
+        /** Possible error reason values. */
         @SuppressWarnings("InnerClassTooDeeplyNested")
         enum Reason {
             UNEXPECTED("UNEXPECTED"),

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -544,7 +544,7 @@ public class CallSpecTest {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{\n"
               + "  \"msg\": \"success\",\n"
               + "  \"code\": 200\n"
-              + "}"));
+              + '}'));
 
         CallSpec<TestMsg, Object> spec = this.<TestMsg, Object>builder(HttpMethod.GET, "/", false)
               .responseAs(TestMsg.class)
@@ -569,7 +569,7 @@ public class CallSpecTest {
               + "      \"reason\": \"UNEXPECTED\"\n"
               + "    }\n"
               + "  ]\n"
-              + "}"));
+              + '}'));
 
         CallSpec<Object, HttpError> spec = this.<Object, HttpError>builder(HttpMethod.GET, "/", false)
               .responseAs(Object.class)
@@ -608,7 +608,7 @@ public class CallSpecTest {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{\n"
               + "  \"msg\": \"Hey!\",\n"
               + "  \"code\": 42\n"
-              + "}"));
+              + '}'));
 
         CallSpec<TestMsg, Object> spec = this.<TestMsg, Object>builder(HttpMethod.GET, "/", false)
               .responseAs(TestMsg.class)
@@ -632,7 +632,7 @@ public class CallSpecTest {
               + "      \"reason\": \"FIELD_DEPRECATED\"\n"
               + "    }\n"
               + "  ]\n"
-              + "}"));
+              + '}'));
 
         CallSpec<Object, Object> spec = builder(HttpMethod.DELETE, "/", false)
               .responseAs(Object.class)


### PR DESCRIPTION
Since `HttpError` is a object parsed by moshi from the error body, we don't need to expose it's constructors.
