### PR TITLE
Generify CallSpec.

### DIFF
--- a/api-client/src/main/java/com/xing/api/CompositeType.java
+++ b/api-client/src/main/java/com/xing/api/CompositeType.java
@@ -70,7 +70,7 @@ final class CompositeType implements ParameterizedType {
     final String[] roots;
     final Structure structure;
 
-    CompositeType(Type ownerType, Type searchFor, Structure structure, String... roots) {
+    CompositeType(@Nullable Type ownerType, Type searchFor, Structure structure, String... roots) {
         this.ownerType = ownerType;
         this.searchFor = searchFor;
         this.structure = structure;
@@ -82,6 +82,7 @@ final class CompositeType implements ParameterizedType {
         return new Type[]{toFind()};
     }
 
+    @Nullable
     @Override
     public Type getOwnerType() {
         return ownerType;

--- a/api-client/src/main/java/com/xing/api/Resource.java
+++ b/api-client/src/main/java/com/xing/api/Resource.java
@@ -16,7 +16,6 @@
 package com.xing.api;
 
 import java.lang.reflect.Type;
-import java.util.List;
 
 /**
  * TODO docs.
@@ -69,30 +68,5 @@ public abstract class Resource {
      */
     protected static Type first(Type searchFor, String... roots) {
         return new CompositeType(null, searchFor, CompositeType.Structure.FIRST, roots);
-    }
-
-    /**
-     * Converts a list of strings into a string with coma separated values. If the list is {@code null} or empty an
-     * empty string will be returned.
-     */
-    protected static String csv(List<String> values) {
-        StringBuilder sb = new StringBuilder();
-        if (values != null && !values.isEmpty()) {
-            int size = values.size();
-            if (size > 1) {
-                boolean firstTime = true;
-                for (int index = 0; index < size; index++) {
-                    if (firstTime) {
-                        firstTime = false;
-                    } else {
-                        sb.append(", ");
-                    }
-                    sb.append(values.get(index));
-                }
-            } else {
-                sb.append(values.get(0));
-            }
-        }
-        return sb.toString();
     }
 }

--- a/api-client/src/main/java/com/xing/api/resources/ContactsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ContactsResource.java
@@ -94,7 +94,7 @@ public class ContactsResource extends Resource {
     public CallSpec<List<XingUser>, HttpError> getContacts(String userId) {
         return Resource.<List<XingUser>, HttpError>newGetSpec(api, "/v1/users/{user_id}/contacts")
               .pathParam("user_id", userId)
-              .responseAsListOf(XingUser.class, "contacts, users")
+              .responseAs(list(XingUser.class, "contacts, users"))
               .build();
     }
 
@@ -112,7 +112,7 @@ public class ContactsResource extends Resource {
      */
     public CallSpec<List<String>, HttpError> getYourContactIds() {
         return Resource.<List<String>, HttpError>newGetSpec(api, "/v1/users/me/contact_ids")
-              .responseAsListOf(String.class, "contact_ids", "items")
+              .responseAs(list(String.class, "contact_ids", "items"))
               .build();
     }
 
@@ -165,7 +165,7 @@ public class ContactsResource extends Resource {
     public CallSpec<List<XingUser>, HttpError> getSharedContacts(String userId) {
         return Resource.<List<XingUser>, HttpError>newGetSpec(api, "/v1/users/{user_id}/contacts/shared")
               .pathParam("user_id", userId)
-              .responseAsListOf(XingUser.class, "shared_contacts", "users")
+              .responseAs(list(XingUser.class, "shared_contacts", "users"))
               .build();
     }
 
@@ -190,7 +190,7 @@ public class ContactsResource extends Resource {
     public CallSpec<List<XingUser>, HttpError> getUpcomingBirthdays(String userId) {
         return Resource.<List<XingUser>, HttpError>newGetSpec(api, "/v1/users/{user_id}/contacts/shared")
               .pathParam("user_id", userId)
-              .responseAsListOf(XingUser.class, "users")
+              .responseAs(list(XingUser.class, "users"))
               .build();
     }
 
@@ -224,7 +224,7 @@ public class ContactsResource extends Resource {
      */
     public CallSpec<List<ContactRequest>, HttpError> getIncomingContactRequests() {
         return Resource.<List<ContactRequest>, HttpError>newGetSpec(api, "/v1/users/me/contact_requests")
-              .responseAsListOf(ContactRequest.class, "contact_requests")
+              .responseAs(list(ContactRequest.class, "contact_requests"))
               .build();
     }
 
@@ -255,7 +255,7 @@ public class ContactsResource extends Resource {
      */
     public CallSpec<List<PendingContactRequest>, HttpError> getPendingContactRequests() {
         return Resource.<List<PendingContactRequest>, HttpError>newGetSpec(api, " /v1/users/me/contact_requests/sent")
-              .responseAsListOf(PendingContactRequest.class, "contact_requests")
+              .responseAs(list(PendingContactRequest.class, "contact_requests"))
               .build();
     }
 
@@ -354,7 +354,7 @@ public class ContactsResource extends Resource {
         return Resource.<ContactPaths, HttpError>newGetSpec(api, "/v1/users/{user_id}/network/{other_user_id}/paths")
               .pathParam("user_id", userId)
               .pathParam("other_user_id", otherUserId)
-              .responseAs(ContactPaths.class, "contact_paths")
+              .responseAs(single(ContactPaths.class, "contact_paths"))
               .build();
     }
 
@@ -387,9 +387,8 @@ public class ContactsResource extends Resource {
      */
     public CallSpec<InvitationStats, HttpError> sendInvitation(String... toEmails) {
         return Resource.<InvitationStats, HttpError>newPostSpec(api, "/v1/users/invite", true)
-              //TODO SerjLtt|DanielH Make this array a string which is comma seperated
-              .pathParam("to_emails", toEmails.toString())
-              .responseAs(InvitationStats.class, "invitation_stats")
+              .pathParam("to_emails", toEmails)
+              .responseAs(single(InvitationStats.class, "invitation_stats"))
               .build();
     }
 }

--- a/api-client/src/main/java/com/xing/api/resources/ProfileVisitsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ProfileVisitsResource.java
@@ -47,7 +47,7 @@ public class ProfileVisitsResource extends Resource {
     public CallSpec<List<ProfileVisit>, HttpError> getProfileVisits(String userId) {
         return Resource.<List<ProfileVisit>, HttpError>newGetSpec(api, "/v1/users/{user_id}/visits")
               .pathParam("user_id", userId)
-              .responseAsListOf(ProfileVisit.class)
+              .responseAs(list(ProfileVisit.class))
               .build();
     }
 

--- a/api-client/src/main/java/com/xing/api/resources/UserProfilesResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/UserProfilesResource.java
@@ -59,8 +59,8 @@ public class UserProfilesResource extends Resource {
      */
     public CallSpec<List<XingUser>, HttpError> getUsersById(List<String> ids) {
         return Resource.<List<XingUser>, HttpError>newGetSpec(api, "/v1/users/{ids}")
-              .pathParam("ids", csv(ids))
-              .responseAsListOf(XingUser.class, "users")
+              .pathParam("ids", ids)
+              .responseAs(list(XingUser.class, "users"))
               .build();
     }
 
@@ -80,7 +80,7 @@ public class UserProfilesResource extends Resource {
     public CallSpec<XingUser, HttpError> getUserById(String id) {
         return Resource.<XingUser, HttpError>newGetSpec(api, "/v1/users/{id}")
               .pathParam("id", id)
-              .responseAsFirst(XingUser.class, "users")
+              .responseAs(first(XingUser.class, "users"))
               .build();
     }
 
@@ -111,7 +111,7 @@ public class UserProfilesResource extends Resource {
      */
     public CallSpec<XingUser, HttpError> getOwnIdCard() {
         return Resource.<XingUser, HttpError>newGetSpec(api, "/v1/users/me/id_card")
-              .responseAs(XingUser.class, "id_card")
+              .responseAs(single(XingUser.class, "id_card"))
               .build();
     }
 
@@ -133,8 +133,8 @@ public class UserProfilesResource extends Resource {
      */
     public CallSpec<List<XingUser>, HttpError> findUsersByEmail(List<String> emails) {
         return Resource.<List<XingUser>, HttpError>newGetSpec(api, "/v1/users/find_by_emails")
-              .responseAsListOf(single(XingUser.class, "user"), "results", "items")
-              .queryParam("emails", csv(emails))
+              .responseAs(list(single(XingUser.class, "user"), "results", "items"))
+              .queryParam("emails", emails)
               .build();
     }
 
@@ -162,7 +162,7 @@ public class UserProfilesResource extends Resource {
     @Experimental
     public CallSpec<List<XingUser>, HttpError> findUsersByKeyword(String keywords) {
         return Resource.<List<XingUser>, HttpError>newGetSpec(api, "/v1/users/find")
-              .responseAsListOf(single(XingUser.class, "user"), "users", "items")
+              .responseAs(list(single(XingUser.class, "user"), "users", "items"))
               .queryParam("keywords", keywords)
               .build();
     }
@@ -178,7 +178,7 @@ public class UserProfilesResource extends Resource {
     public CallSpec<ProfileMessage, HttpError> getUserProfileMessage(String userId) {
         return Resource.<ProfileMessage, HttpError>newGetSpec(api, "/v1/{user_id}/profile_message")
               .pathParam("user_id", userId)
-              .responseAs(ProfileMessage.class, "profile_message")
+              .responseAs(single(ProfileMessage.class, "profile_message"))
               .build();
     }
 
@@ -206,7 +206,7 @@ public class UserProfilesResource extends Resource {
     public CallSpec<String, HttpError> getUserLegalInformation(String userId) {
         return Resource.<String, HttpError>newGetSpec(api, "/v1/users/{user_id}/legal_information")
               .pathParam("user_id", userId)
-              .responseAs(String.class, "legal_information", "content")
+              .responseAs(single(String.class, "legal_information", "content"))
               .build();
     }
 


### PR DESCRIPTION
This removes any awareness about the `CompositeType` from the spec. Now it's the resource responsibility to specify the right type.
Also the `toCsv()` utility method moved to `CallSpec` internals. This will allow the user to specify lists as single query and form params directly to the spec.
