### PR TITLE
NullInt annotation for 'null' primitives.

### DIFF
--- a/api-client/src/main/java/com/xing/api/XingApi.java
+++ b/api-client/src/main/java/com/xing/api/XingApi.java
@@ -26,6 +26,7 @@ import com.xing.api.internal.json.CsvCollectionJsonAdapter;
 import com.xing.api.internal.json.GenderJsonAdapter;
 import com.xing.api.internal.json.LanguageJsonAdapter;
 import com.xing.api.internal.json.MessagingAccountJsonAdapter;
+import com.xing.api.internal.json.NullIntJsonAdapter;
 import com.xing.api.internal.json.PhoneJsonAdapter;
 import com.xing.api.internal.json.PremiumServiceJsonAdapter;
 import com.xing.api.internal.json.SafeCalendarJsonAdapter;
@@ -192,6 +193,7 @@ public final class XingApi {
             // Add the custom JSON Adapters to Moshi
             if (moshiBuilder == null) moshiBuilder = new Moshi.Builder();
             moshiBuilder.add(CompositeTypeJsonAdapter.FACTORY);
+            moshiBuilder.add(NullIntJsonAdapter.FACTORY);
             moshiBuilder.add(BirthDateJsonAdapter.FACTORY);
             moshiBuilder.add(SafeCalendarJsonAdapter.FACTORY);
             moshiBuilder.add(PhoneJsonAdapter.FACTORY);

--- a/api-client/src/main/java/com/xing/api/internal/json/NullInt.java
+++ b/api-client/src/main/java/com/xing/api/internal/json/NullInt.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (С) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api.internal.json;
+
+import com.squareup.moshi.JsonQualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/** Represents an integer value, that accepts {@code null}. */
+@Documented
+@JsonQualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullInt {
+}

--- a/api-client/src/main/java/com/xing/api/internal/json/NullIntJsonAdapter.java
+++ b/api-client/src/main/java/com/xing/api/internal/json/NullIntJsonAdapter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (С) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api.internal.json;
+
+import android.support.annotation.Nullable;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+/** Adapter for integer values annotated with {@linkplain NullInt}. */
+public final class NullIntJsonAdapter extends JsonAdapter<Integer> {
+    public static final JsonAdapter.Factory FACTORY = new Factory() {
+        @Nullable
+        @Override
+        public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+            if (annotations.isEmpty() || annotations.size() != 1
+                  // At this point we know that the set contains only one entry.
+                  || annotations.iterator().next().annotationType() != NullInt.class) {
+                return null;
+            }
+            Class<?> rawType = Types.getRawType(type);
+            if (rawType == int.class || rawType == Integer.class) return new NullIntJsonAdapter();
+            return null;
+        }
+    };
+
+    NullIntJsonAdapter() {
+    }
+
+    @Override
+    public Integer fromJson(JsonReader reader) throws IOException {
+        if (reader.peek() == JsonReader.Token.NULL) {
+            return -1;
+        } else {
+            return reader.nextInt();
+        }
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, Integer value) throws IOException {
+        if (value == null || value == -1) {
+            writer.nullValue();
+        } else {
+            writer.value(value.intValue());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "JsonAdapter(NullInt)";
+    }
+}

--- a/api-client/src/test/java/com/xing/api/internal/json/NullIntJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/NullIntJsonAdapterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (С) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api.internal.json;
+
+import android.support.annotation.Nullable;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author serj.lotutovici
+ */
+@SuppressWarnings("ConstantConditions")
+public class NullIntJsonAdapterTest {
+    private static final Set<Annotation> WITH_NO_ANNOTATIONS = Collections.emptySet();
+    private static final Set<Annotation> WITH_NI_ANNOTATION = new HashSet<>(1);
+    private static final Set<Annotation> WITH_NO_NI_ANNOTATION = new HashSet<>(1);
+    private static final Set<Annotation> WITH_NO_NI_ANNOTATION2 = new HashSet<>(2);
+
+    static {
+        WITH_NI_ANNOTATION.add(new Annotation() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return NullInt.class;
+            }
+        });
+
+        WITH_NO_NI_ANNOTATION.add(new Annotation() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return Test.class;
+            }
+        });
+
+        WITH_NO_NI_ANNOTATION2.addAll(WITH_NO_NI_ANNOTATION);
+        WITH_NO_NI_ANNOTATION2.add(new Annotation() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return Nullable.class;
+            }
+        });
+    }
+
+    private final Moshi moshi = new Moshi.Builder().build();
+
+    @Test
+    public void ignoresUnsupportedTypes() throws Exception {
+        assertThat(nullIntAdapter(int.class, WITH_NO_ANNOTATIONS)).isNull();
+        assertThat(nullIntAdapter(Integer.class, WITH_NO_ANNOTATIONS)).isNull();
+        assertThat(nullIntAdapter(int.class, WITH_NO_NI_ANNOTATION)).isNull();
+        assertThat(nullIntAdapter(int.class, WITH_NO_NI_ANNOTATION2)).isNull();
+        assertThat(nullIntAdapter(String.class, WITH_NI_ANNOTATION)).isNull();
+    }
+
+    @Test
+    public void intValues() throws Exception {
+        assertThat(fromJson("0")).isEqualTo(0);
+        assertThat(fromJson("3")).isEqualTo(3);
+        assertThat(fromJson("-56")).isEqualTo(-56);
+
+        assertThat(toJson(0)).isEqualTo("0");
+        assertThat(toJson(2)).isEqualTo("2");
+        assertThat(toJson(-42)).isEqualTo("-42");
+    }
+
+    @Test
+    public void nullValues() throws Exception {
+        assertThat(fromJson("null")).isEqualTo(-1);
+        assertThat(toJson(-1)).isEqualTo("null");
+        assertThat(toJson(null)).isEqualTo("null");
+    }
+
+    protected String toJson(Integer value) throws IOException {
+        JsonAdapter<Integer> adapter = nullIntAdapter(int.class, WITH_NI_ANNOTATION);
+        return adapter.lenient().toJson(value);
+    }
+
+    private Integer fromJson(String json) throws IOException {
+        JsonAdapter<Integer> adapter = nullIntAdapter(int.class, WITH_NI_ANNOTATION);
+        return adapter.lenient().fromJson(json);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private <T> JsonAdapter<T> nullIntAdapter(Type type,
+          Set<? extends Annotation> annotations) {
+        return (JsonAdapter<T>) NullIntJsonAdapter.FACTORY.create(type, annotations, moshi);
+    }
+}


### PR DESCRIPTION
Our api doesn't stop surprising... Some responses can return a `null` value for some something that is normally a positive `int`. Since we want to avoid constant boxing/unboxing, here is a small contract annotation.
