### PR TITLE
Add millis supported format to SafeCalendarJsonAdapter.

### DIFF
--- a/api-client/src/main/java/com/xing/api/internal/json/SafeCalendarJsonAdapter.java
+++ b/api-client/src/main/java/com/xing/api/internal/json/SafeCalendarJsonAdapter.java
@@ -54,9 +54,11 @@ public final class SafeCalendarJsonAdapter<T extends Calendar> extends JsonAdapt
     private static final String REG_EX_YEAR_MONTH_DAY = "^(19|20)\\d{2}-\\d{2}-\\d{2}$";
     private static final String REG_EX_ISO_DATE_Z = "^(19|20)\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$";
     private static final String REG_EX_ISO_DATE_TIME = "^(19|20)\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+]\\d{4}$";
+    private static final String REG_EX_ISO_DATE_WEIRD = "^(19|20)\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z$";
 
     private static final String ISO_DATE_FORMAT_Z = "yyyy-MM-dd'T'HH:mm:ss'Z'";
     private static final String ISO_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+    private static final String ISO_DATE_FORMAT_WEIRD = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     private static final String YEAR_DATE_FORMAT = "yyyy";
     private static final String YEAR_MONTH_DATE_FORMAT = "yyyy-MM";
     private static final String YEAR_MONTH_DAY_DATE_FORMAT = "yyyy-MM-dd";
@@ -70,6 +72,7 @@ public final class SafeCalendarJsonAdapter<T extends Calendar> extends JsonAdapt
         DATE_FORMAT_MAP.put(REG_EX_YEAR_MONTH_DAY, new SimpleDateFormat(YEAR_MONTH_DAY_DATE_FORMAT));
         DATE_FORMAT_MAP.put(REG_EX_ISO_DATE_Z, new SimpleDateFormat(ISO_DATE_FORMAT_Z));
         DATE_FORMAT_MAP.put(REG_EX_ISO_DATE_TIME, new SimpleDateFormat(ISO_DATE_FORMAT));
+        DATE_FORMAT_MAP.put(REG_EX_ISO_DATE_WEIRD, new SimpleDateFormat(ISO_DATE_FORMAT_WEIRD));
     }
 
     public static final Factory FACTORY = new Factory() {
@@ -104,8 +107,10 @@ public final class SafeCalendarJsonAdapter<T extends Calendar> extends JsonAdapt
             }
         }
 
-        // No supported format
-        if (format == null) return null;
+        // Throw if no supported format, so that we don't fail silently.
+        if (format == null) {
+            throw new AssertionError("Unsupported date format! Expecting ISO 8601, but found: " + dateStr);
+        }
 
         try {
             // Try to parse the date


### PR DESCRIPTION
an additional format for support by safe calendar. It seams like our feed responses return an additional `*.000` value, which was ignored before.
