### PR TITLE
Expose converter and api endpoint via public accessors.

### DIFF
--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -251,7 +251,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
 
     /** Returns a raw {@link Call} pre-building the targeted request. */
     private Call createRawCall() {
-        return api.client.newCall(builder.request());
+        return api.client().newCall(builder.request());
     }
 
     /** Parsers the OkHttp raw response and returns an response ready to be consumed by the caller. */
@@ -312,7 +312,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
             if (rawType == Void.class) return null;
             if (rawType == String.class) return (PT) body.string();
 
-            JsonAdapter<PT> adapter = api.converter.adapter(type);
+            JsonAdapter<PT> adapter = api.converter().adapter(type);
             JsonReader reader = JsonReader.of(body.source());
             return adapter.fromJson(reader);
         } finally {
@@ -352,7 +352,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
             this.resourcePath = checkNotNull(resourcePath, "resourcePath == null");
 
             resourcePathParams = parseResourcePathParams(resourcePath);
-            apiEndpoint = api.apiEndpoint;
+            apiEndpoint = api.apiEndpoint();
             requestBuilder = new Request.Builder().header("Accept", "application/json");
 
             if (isFormEncoded) formEncodingBuilder = new FormEncodingBuilder();
@@ -441,7 +441,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
         //TODO Avoid converting response body on main thread?
         public <U> Builder<RT, ET> body(Type type, U body) {
             Buffer buffer = new Buffer();
-            JsonAdapter<U> jsonAdapter = api.converter.adapter(type);
+            JsonAdapter<U> jsonAdapter = api.converter().adapter(type);
             try {
                 jsonAdapter.toJson(buffer, body);
             } catch (IOException ignored) {

--- a/api-client/src/main/java/com/xing/api/XingApi.java
+++ b/api-client/src/main/java/com/xing/api/XingApi.java
@@ -44,9 +44,9 @@ public final class XingApi {
     @SuppressWarnings("CollectionWithoutInitialCapacity")
     private final Map<Class<? extends Resource>, Resource> resourcesCache = new LinkedHashMap<>();
 
-    final OkHttpClient client;
-    final HttpUrl apiEndpoint;
-    final Moshi converter;
+    private final OkHttpClient client;
+    private final HttpUrl apiEndpoint;
+    private final Moshi converter;
 
     XingApi(OkHttpClient client, HttpUrl apiEndpoint, Moshi converter) {
         this.client = client;
@@ -70,6 +70,23 @@ public final class XingApi {
             }
         }
         return (T) res;
+    }
+
+    /** Returns the api endpoint for <strong>this</strong> client instance. */
+    public HttpUrl apiEndpoint() {
+        return apiEndpoint;
+    }
+
+    /**
+     * Returns the json converter ({@linkplain Moshi} instance) associated with <strong>this</strong> client
+     * instance.
+     */
+    public Moshi converter() {
+        return converter;
+    }
+
+    OkHttpClient client() {
+        return client;
     }
 
     /** Throws an exception if class was declared non-static or non-final. */

--- a/api-client/src/test/java/com/xing/api/JsonSerializationTest.java
+++ b/api-client/src/test/java/com/xing/api/JsonSerializationTest.java
@@ -63,7 +63,7 @@ public class JsonSerializationTest {
 
     @Test
     public void user() throws Exception {
-        JsonAdapter<XingUser> adapter = api.converter.adapter(XingUser.class);
+        JsonAdapter<XingUser> adapter = api.converter().adapter(XingUser.class);
         String json = file("user.json");
 
         // Test that the user object reflects the json.


### PR DESCRIPTION
This will allow clients to access the api clients converter and api endpoint.
