### PR TITLE
Introduce CallbackAdapter allowing to run callbacks custom executor.

### DIFF
--- a/api-client-android-oauth/build.gradle
+++ b/api-client-android-oauth/build.gradle
@@ -55,9 +55,11 @@ android {
 }
 
 dependencies {
-    provided libraries.supportAnnotations
+    compile(project(':api-client')) {
+        exclude group: 'com.google.android', module: 'android'
+    }
 
-    compile project(':api-client')
+    provided libraries.supportAnnotations
     compile libraries.singpost
 }
 /*

--- a/api-client-android-sample/build.gradle
+++ b/api-client-android-sample/build.gradle
@@ -73,7 +73,6 @@ android {
 }
 
 dependencies {
-    compile project(':api-client')
     compile project(':api-client-android-oauth')
 
     compile libraries.okhttpLoggingInterceptor

--- a/api-client/build.gradle
+++ b/api-client/build.gradle
@@ -38,6 +38,7 @@ checkstyle {
 
 dependencies {
     provided libraries.rxjava
+    provided libraries.android
 
     compile libraries.okio
     compile libraries.okhttp

--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -125,15 +125,14 @@ public final class CallSpec<RT, ET> implements Cloneable {
             callback.onFailure(t);
             return;
         }
-        if (canceled) {
-            rawCall.cancel();
-        }
+
+        if (canceled) rawCall.cancel();
         this.rawCall = rawCall;
 
         rawCall.enqueue(new com.squareup.okhttp.Callback() {
             private void callFailure(Throwable e) {
                 try {
-                    callback.onFailure(e);
+                    api.callbackAdapter().adapt(callback).onFailure(e);
                 } catch (Throwable t) {
                     // TODO add some logging
                 }
@@ -141,7 +140,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
 
             private void callSuccess(Response<RT, ET> response) {
                 try {
-                    callback.onResponse(response);
+                    api.callbackAdapter().adapt(callback).onResponse(response);
                 } catch (Throwable t) {
                     // TODO add some logging
                 }

--- a/api-client/src/main/java/com/xing/api/CallbackAdapter.java
+++ b/api-client/src/main/java/com/xing/api/CallbackAdapter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api;
+
+/**
+ * Callback adapter contract, that will decorate/adapt the passed callback to be executed on the appropriate
+ * executor.
+ */
+interface CallbackAdapter {
+    /** Adapts the passed callback. */
+    <RT, ET> Callback<RT, ET> adapt(Callback<RT, ET> callback);
+
+    /** Default callback adapter. DOESN'T alter the passed callbacks. */
+    final class Default implements CallbackAdapter {
+        @Override
+        public <RT, ET> Callback<RT, ET> adapt(Callback<RT, ET> callback) {
+            return callback;
+        }
+    }
+}

--- a/api-client/src/main/java/com/xing/api/ExecutorCallbackAdapter.java
+++ b/api-client/src/main/java/com/xing/api/ExecutorCallbackAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api;
+
+import java.util.concurrent.Executor;
+
+/** Callback adapter that allows invoking callback methods on the set executor thread. */
+final class ExecutorCallbackAdapter implements CallbackAdapter {
+    private final Executor executor;
+
+    public ExecutorCallbackAdapter(Executor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public <RT, ET> Callback<RT, ET> adapt(final Callback<RT, ET> callback) {
+        return new Callback<RT, ET>() {
+            @Override
+            public void onResponse(final Response<RT, ET> response) {
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        callback.onResponse(response);
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(final Throwable t) {
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        callback.onFailure(t);
+                    }
+                });
+            }
+        };
+    }
+}

--- a/api-client/src/main/java/com/xing/api/Platform.java
+++ b/api-client/src/main/java/com/xing/api/Platform.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 XING AG (http://xing.com/)
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api;
+
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.concurrent.Executor;
+
+/** Provides platform specific adapters. */
+class Platform {
+    private static final Platform PLATFORM = findPlatform();
+
+    static Platform get() {
+        return PLATFORM;
+    }
+
+    private static Platform findPlatform() {
+        try {
+            Class.forName("android.os.Build");
+            if (Build.VERSION.SDK_INT != 0) {
+                return new Android();
+            }
+        } catch (ClassNotFoundException ignored) {
+        }
+        return new Platform();
+    }
+
+    /** Returns a callback adapter for the corresponding executor. */
+    public CallbackAdapter callbackAdapter(Executor executor) {
+        if (executor != null) return new ExecutorCallbackAdapter(executor);
+        return new CallbackAdapter.Default();
+    }
+
+    static class Android extends Platform {
+        @Override
+        public CallbackAdapter callbackAdapter(Executor executor) {
+            if (executor == null) executor = new MainThreadExecutor();
+            return new ExecutorCallbackAdapter(executor);
+        }
+
+        @SuppressWarnings("NullableProblems") // No need for non-null annotation.
+        static class MainThreadExecutor implements Executor {
+            private final Handler handler = new Handler(Looper.getMainLooper());
+
+            @Override
+            public void execute(Runnable runnable) {
+                handler.post(runnable);
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ allprojects {
               supportDesign           : 'com.android.support:design:22.2.0',
               supportCardView         : 'com.android.support:cardview-v7:22.2.0',
               supportRecyclerView     : 'com.android.support:recyclerview-v7:22.2.0',
+              android                 : 'com.google.android:android:4.1.1.4',
 
               // Ok stack
               okhttp                  : 'com.squareup.okhttp:okhttp:2.7.2',


### PR DESCRIPTION
Adds a Platform utility class that allows deffining on which platfrom
the code is executed (forked from Retrofit).
Two Callback executers are used. Default - empty one, an executor based
one.
