### PR TITLE
Add AuthErrorCallback. Treat 401 as a failure.

### DIFF
--- a/api-client/src/main/java/com/xing/api/AuthErrorCallback.java
+++ b/api-client/src/main/java/com/xing/api/AuthErrorCallback.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api;
+
+import com.squareup.okhttp.ResponseBody;
+
+/** A callback contract that allows to intercept auth errors in a centralized way. */
+public interface AuthErrorCallback {
+    /** Called when the server responded with an authentication error. */
+    void onAuthError(Response<?, ResponseBody> errorResponse);
+}

--- a/api-client/src/main/java/com/xing/api/CallbackAdapter.java
+++ b/api-client/src/main/java/com/xing/api/CallbackAdapter.java
@@ -23,10 +23,18 @@ interface CallbackAdapter {
     /** Adapts the passed callback. */
     <RT, ET> Callback<RT, ET> adapt(Callback<RT, ET> callback);
 
+    /** Adapts the passed auth callback. */
+    AuthErrorCallback adapt(AuthErrorCallback callback);
+
     /** Default callback adapter. DOESN'T alter the passed callbacks. */
     final class Default implements CallbackAdapter {
         @Override
         public <RT, ET> Callback<RT, ET> adapt(Callback<RT, ET> callback) {
+            return callback;
+        }
+
+        @Override
+        public AuthErrorCallback adapt(AuthErrorCallback callback) {
             return callback;
         }
     }

--- a/api-client/src/main/java/com/xing/api/ExecutorCallbackAdapter.java
+++ b/api-client/src/main/java/com/xing/api/ExecutorCallbackAdapter.java
@@ -15,6 +15,8 @@
  */
 package com.xing.api;
 
+import com.squareup.okhttp.ResponseBody;
+
 import java.util.concurrent.Executor;
 
 /** Callback adapter that allows invoking callback methods on the set executor thread. */
@@ -44,6 +46,21 @@ final class ExecutorCallbackAdapter implements CallbackAdapter {
                     @Override
                     public void run() {
                         callback.onFailure(t);
+                    }
+                });
+            }
+        };
+    }
+
+    @Override
+    public AuthErrorCallback adapt(final AuthErrorCallback callback) {
+        return new AuthErrorCallback() {
+            @Override
+            public void onAuthError(final Response<?, ResponseBody> errorResponse) {
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        callback.onAuthError(errorResponse);
                     }
                 });
             }

--- a/api-client/src/main/java/com/xing/api/Utils.java
+++ b/api-client/src/main/java/com/xing/api/Utils.java
@@ -17,8 +17,12 @@
  */
 package com.xing.api;
 
+import com.squareup.okhttp.ResponseBody;
+
 import java.io.Closeable;
 import java.io.IOException;
+
+import okio.Buffer;
 
 final class Utils {
     /**
@@ -52,6 +56,13 @@ final class Utils {
             closeable.close();
         } catch (IOException ignored) {
         }
+    }
+
+    /** Buffers the response body, allowing to close the original source. */
+    static ResponseBody buffer(ResponseBody body) throws IOException {
+        Buffer buffer = new Buffer();
+        body.source().readAll(buffer);
+        return ResponseBody.create(body.contentType(), body.contentLength(), buffer);
     }
 
     /** Returns a {@link RuntimeException} with a formatted error message. */

--- a/api-client/src/main/java/com/xing/api/data/profile/XingUser.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/XingUser.java
@@ -511,7 +511,7 @@ public class XingUser implements Serializable {
         return this;
     }
 
-    public XingUser addTpWebProfile(WebProfile webProfile, String accountName) {
+    public XingUser addToWebProfile(WebProfile webProfile, String accountName) {
         if (webProfiles == null) webProfiles = new LinkedHashMap<>();
         if (!webProfiles.containsKey(webProfile)) webProfiles.put(webProfile, new LinkedHashSet<String>());
         webProfiles.get(webProfile).add(accountName);


### PR DESCRIPTION
Centralize the auth error handling. Every time the server will respond with 401, the auth callbacks will be notified. This allows the consumer to keep authorisation logic on one place without the need to handle it on every spec invocation.

Closes #49 
