### PR TITLE
Allow DELETE requests to have a form body.

### DIFF
--- a/api-client/src/main/java/com/xing/api/Resource.java
+++ b/api-client/src/main/java/com/xing/api/Resource.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Type;
  */
 public abstract class Resource {
     protected static final String ME = "me";
+
     protected final XingApi api;
 
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
@@ -49,8 +50,9 @@ public abstract class Resource {
     }
 
     /** Returns a {@link CallSpec.Builder} for a DELETE request. */
-    protected static <RT, ET> CallSpec.Builder<RT, ET> newDeleteSpec(XingApi api, String resourcePath) {
-        return new CallSpec.Builder<>(api, HttpMethod.DELETE, resourcePath, false);
+    protected static <RT, ET> CallSpec.Builder<RT, ET> newDeleteSpec(XingApi api, String resourcePath,
+          boolean isFormEncoded) {
+        return new CallSpec.Builder<>(api, HttpMethod.DELETE, resourcePath, isFormEncoded);
     }
 
     /** Returns a {@link Type} that will expect a single object in the root json tree. */

--- a/api-client/src/main/java/com/xing/api/resources/BookmarksResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/BookmarksResource.java
@@ -97,7 +97,7 @@ public final class BookmarksResource extends Resource {
      * page.</a>
      */
     public CallSpec<Void, HttpError> deleteOwnBookmark(String userId) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/bookmarks/{id}")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/bookmarks/{id}", false)
               .responseAs(Void.class)
               .pathParam("id", userId)
               .build();

--- a/api-client/src/main/java/com/xing/api/resources/ContactsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ContactsResource.java
@@ -380,7 +380,7 @@ public final class ContactsResource extends Resource {
      */
     // TODO docs.
     public CallSpec<Void, HttpError> revokeContactRequest(String recipientId, String senderId) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/{user_id}/contact_requests/{sender_id}")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/{user_id}/contact_requests/{sender_id}", false)
               .pathParam("user_id", recipientId)
               .pathParam("sender_id", senderId)
               .responseAs(Void.class)

--- a/api-client/src/main/java/com/xing/api/resources/ProfileEditingResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ProfileEditingResource.java
@@ -158,7 +158,7 @@ public final class ProfileEditingResource extends Resource {
      * resource page</a>
      */
     public CallSpec<Void, HttpError> deleteProfilePicture() {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "v1/users/me/photo")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "v1/users/me/photo", false)
               .responseAs(Void.class)
               .build();
     }
@@ -478,7 +478,7 @@ public final class ProfileEditingResource extends Resource {
      * resource page.</a>
      */
     public CallSpec<Void, HttpError> deleteSchool(String schoolId) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/educational_background/schools/{id}")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/educational_background/schools/{id}", false)
               .responseAs(Void.class)
               .pathParam("id", schoolId)
               .build();
@@ -689,7 +689,8 @@ public final class ProfileEditingResource extends Resource {
      * resource page.</a>
      */
     public CallSpec<Void, HttpError> deleteCompany(String companyId) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/professional_experience/companies/{id}")
+        return Resource.<Void, HttpError>newDeleteSpec(api,
+              "/v1/users/me/professional_experience/companies/{id}", false)
               .responseAs(Void.class)
               .pathParam("id", companyId)
               .build();
@@ -759,7 +760,7 @@ public final class ProfileEditingResource extends Resource {
      * @see <a href="https://dev.xing.com/docs/delete/users/me/languages/:language">'Delete Language' resource page.</a>
      */
     public CallSpec<Void, HttpError> deleteLanguage(Language language) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/languages/{language}")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/languages/{language}", false)
               .responseAs(Void.class)
               .pathParam("language", language.toString())
               .build();
@@ -814,7 +815,7 @@ public final class ProfileEditingResource extends Resource {
      * page.</a>
      */
     public CallSpec<Void, HttpError> deleteWebProfile(WebProfile profile) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/web_profiles/{profile}")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/web_profiles/{profile}", false)
               .responseAs(Void.class)
               .pathParam("profile", profile.toString())
               .build();
@@ -852,7 +853,7 @@ public final class ProfileEditingResource extends Resource {
      */
     @Experimental
     public CallSpec<Void, HttpError> deleteMessagingAccount(MessagingAccount account) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/instant_messaging_accounts/{account}")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/instant_messaging_accounts/{account}", false)
               .responseAs(Void.class)
               .pathParam("account", account.toString())
               .build();

--- a/api-client/src/main/java/com/xing/api/resources/RecommendationsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/RecommendationsResource.java
@@ -45,7 +45,7 @@ public final class RecommendationsResource extends Resource {
 
     // TODO docs.
     public CallSpec<Void, HttpError> blockRecommendation(String userId) {
-        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/network/recommendations/user/{id}")
+        return Resource.<Void, HttpError>newDeleteSpec(api, "/v1/users/me/network/recommendations/user/{id}", false)
               .pathParam("id", userId)
               .responseAs(Void.class)
               .build();

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -352,6 +352,16 @@ public class CallSpecTest {
     }
 
     @Test
+    public void builderEnsuresDeleteRequestDoesNotHaveABody() throws Exception {
+        CallSpec.Builder builder = builder(HttpMethod.DELETE, "", false).responseAs(Object.class);
+        // Build the CallSpec so that we can build the request.
+        builder.build();
+
+        Request request = builder.request();
+        assertThat(request.body()).isNull();
+    }
+
+    @Test
     public void specThrowsIfCanceled() throws Exception {
         CallSpec spec = builder(HttpMethod.GET, "", false).responseAs(Object.class).build();
         spec.cancel();


### PR DESCRIPTION
This doesn't change the default DELETE request building.
NO empty body will set if not specified.

Closes #99 
