### PR TITLE
Update okhttp to 2.7.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ allprojects {
               android                 : 'com.google.android:android:4.1.1.4',
 
               // Ok stack
-              okhttp                  : 'com.squareup.okhttp:okhttp:2.7.2',
-              okhttpLoggingInterceptor: 'com.squareup.okhttp:logging-interceptor:2.7.2',
+              okhttp                  : 'com.squareup.okhttp:okhttp:2.7.4',
+              okhttpLoggingInterceptor: 'com.squareup.okhttp:logging-interceptor:2.7.4',
               okio                    : 'com.squareup.okio:okio:1.6.0',
               moshi                   : 'com.squareup.moshi:moshi:1.1.0',
 
@@ -69,7 +69,7 @@ allprojects {
               assertj                 : 'org.assertj:assertj-core:1.7.0',
               mockito                 : 'org.mockito:mockito-all:1.10.19',
               robolectric             : 'org.robolectric:robolectric:3.0',
-              mockWebServer           : 'com.squareup.okhttp:mockwebserver:2.7.2',
+              mockWebServer           : 'com.squareup.okhttp:mockwebserver:2.7.4',
               commonsIo               : 'commons-io:commons-io:2.4',
               apacheCommons3          : 'org.apache.commons:commons-lang3:3.4'
         ]


### PR DESCRIPTION
_Update okhttp, the logging interceptor and mockwebserver to version 2.7.4._
Since there was a security flaw in previous versions of okhttp with certificate pinning it is recommended to update okhttp to version 2.7.4 in order to be resistant to this flaw. 
https://publicobject.com/2016/02/11/okhttp-certificate-pinning-vulnerability/
<What has been changed?
<Why has it been changed?
<What has been added?
<What has been fixed?
<What needs to be tested?
<Do you have any GIFs to attach?>

**Reviewer**:
- [x] @serj-lotutovici 
- [x] Allowed to merge
