### PR TITLE
Add isPremium method to see if a user is basic or premium

### DIFF
--- a/api-client/src/main/java/com/xing/api/data/profile/XingUser.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/XingUser.java
@@ -653,4 +653,12 @@ public class XingUser implements Serializable {
 
         return primaryOccupation;
     }
+
+    /**
+     * Returns true or false depending on the size of the PremiumServices list. If it's false it means the user is
+     * basic, otherwise he is premium.
+     */
+    public boolean isPremium() {
+        return premiumServices != null && !premiumServices.isEmpty();
+    }
 }

--- a/api-client/src/test/java/com/xing/api/data/profile/XingUserTest.java
+++ b/api-client/src/test/java/com/xing/api/data/profile/XingUserTest.java
@@ -1,0 +1,74 @@
+package com.xing.api.data.profile;
+
+import com.xing.api.data.SafeCalendar;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author daniel.hartwich
+ */
+public class XingUserTest {
+    private XingUser user;
+
+    @Before
+    public void setUp() throws Exception {
+        user = new XingUser()
+              .addPremiumService(PremiumService.PRIVATE_MESSAGES)
+              .professionalExperience(
+                    new ProfessionalExperience()
+                          .primaryCompany(new Company()
+                                .id("1231241")
+                                .name("Test Company")
+                                .title("Test Worker")
+                                .description("Test Description")
+                                .companySize(CompanySize.SIZE_1_10)
+                                .beginDate(new SafeCalendar(2013))
+                                .endDate(new SafeCalendar(2016))));
+    }
+
+    @Test
+    public void testPrimaryInstitutionName() throws Exception {
+        String primaryInstutionName = "Test Company";
+        assertThat(user.primaryInstitutionName()).isEqualTo(primaryInstutionName);
+        user.professionalExperience(null);
+        user.educationBackground(new EducationalBackground()
+              .primarySchool(new School()
+                    .id("123123")
+                    .name("Universe School")
+                    .beginDate(new SafeCalendar(2001))
+                    .endDate(new SafeCalendar(2015))
+                    .degree("Master of the Universe")
+                    .subject("Universe")));
+        assertThat(user.primaryInstitutionName()).isEqualTo("Universe School");
+    }
+
+    @Test
+    public void testPrimaryOccupationName() throws Exception {
+        String primaryOccupationName = "Test Worker";
+        assertThat(user.primaryOccupationName()).isEqualTo(primaryOccupationName);
+        user.professionalExperience(null);
+        user.educationBackground(new EducationalBackground()
+              .primarySchool(new School()
+                    .id("123123")
+                    .name("Universe School")
+                    .beginDate(new SafeCalendar(2001))
+                    .endDate(new SafeCalendar(2015))
+                    .degree("Master of the Universe")
+                    .subject("Universe")));
+        assertThat(user.primaryOccupationName()).isEqualTo("Master of the Universe");
+    }
+
+    @Test
+    public void testIsPremium() throws Exception {
+        assertThat(user.isPremium()).isEqualTo(true);
+        XingUser basicUser = new XingUser().premiumServices(Collections.<PremiumService>emptyList());
+        assertThat(basicUser.isPremium()).isEqualTo(false);
+        XingUser nullUser = new XingUser().premiumServices(null);
+        assertThat(nullUser.isPremium()).isEqualTo(false);
+    }
+}


### PR DESCRIPTION
_Added a convenience method to check if a user is premium or not._
- Added tests to verify the behaviour 
- Added two small tests for the `primaryInstitutionName` and the `primaryOccupationName` methods
  <What has been changed?
  <Why has it been changed?
  <What has been added?
  <What has been fixed?
  <What needs to be tested?
  <Do you have any GIFs to attach?>

**Reviewer**:
- [x] @serj-lotutovici 
- [x] Changelog
- [x] Unit Tests
