### PR TITLE
Add Support for setting set day of year with SafeCalendar

### DIFF
--- a/api-client/src/main/java/com/xing/api/data/SafeCalendar.java
+++ b/api-client/src/main/java/com/xing/api/data/SafeCalendar.java
@@ -101,6 +101,12 @@ public final class SafeCalendar extends GregorianCalendar {
               + ']';
     }
 
+    @Override
+    public void set(int field, int value) {
+        super.set(field, value);
+        if (field == DAY_OF_YEAR) super.complete();
+    }
+
     /**
      * {@inheritDoc}
      * <p>

--- a/api-client/src/test/java/com/xing/api/data/SafeCalendarTest.java
+++ b/api-client/src/test/java/com/xing/api/data/SafeCalendarTest.java
@@ -1,0 +1,32 @@
+package com.xing.api.data;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for {@link SafeCalendar}.
+ *
+ * @author daniel.hartwich
+ */
+public class SafeCalendarTest {
+    private SafeCalendar calendar;
+
+    @Before
+    public void setUp() throws Exception {
+        calendar = new SafeCalendar();
+    }
+
+    @SuppressWarnings("MagicNumber")
+    @Test
+    public void testSet() throws Exception {
+        calendar.set(Calendar.DAY_OF_YEAR, 53);
+        assertThat(calendar.get(Calendar.MONTH)).isEqualTo(Calendar.FEBRUARY);
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH)).isEqualTo(22);
+        assertThat(calendar.get(Calendar.HOUR)).isEqualTo(0);
+        assertThat(calendar.get(Calendar.YEAR)).isEqualTo(1970);
+    }
+}


### PR DESCRIPTION
_Add support for setting day of year with safe calendar._
Previously, `SafeCalendar.set(Calendar.set(DAY_OF_YEAR, 53)` didn't work correctly.
This adds support for it.

Dependencies:
**Reviewer**:
- [x] @serj-lotutovici 
- [x] Allowed to merge
- [x] Unit Tests
