### PR TITLE
Remove the 'final' qualifier restriction for Resource classes.

### DIFF
--- a/api-client/src/main/java/com/xing/api/XingApi.java
+++ b/api-client/src/main/java/com/xing/api/XingApi.java
@@ -123,15 +123,15 @@ public final class XingApi {
 
     /** Notify all callbacks that the server returned an auth error. */
     void notifyAuthError(Response<?, ResponseBody> rawResponse) {
-        for (AuthErrorCallback callback : authErrorCallbacks) {
-            callbackAdapter.adapt(callback).onAuthError(rawResponse);
+        for (int i = 0, size = authErrorCallbacks.size(); i < size; i++) {
+            AuthErrorCallback callback = authErrorCallbacks.get(i);
+            if (callback != null) callbackAdapter.adapt(callback).onAuthError(rawResponse);
         }
     }
 
     /** Throws an exception if class was declared non-static or non-final. */
     private static void checkResourceClassDeclaration(Class<? extends Resource> resource) {
         int modifiers = resource.getModifiers();
-        if (!Modifier.isFinal(modifiers)) throw new IllegalArgumentException("Resource class must be declared final.");
         if (resource.isLocalClass() || (resource.isMemberClass() && !Modifier.isStatic(modifiers))) {
             throw new IllegalArgumentException("Resource class must be declared static.");
         }

--- a/api-client/src/main/java/com/xing/api/resources/BookmarksResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/BookmarksResource.java
@@ -31,7 +31,7 @@ import java.util.List;
  * @author daniel.hartwich
  * @author serj.lotutovici
  */
-public final class BookmarksResource extends Resource {
+public class BookmarksResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     BookmarksResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/ContactsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ContactsResource.java
@@ -37,7 +37,7 @@ import java.util.List;
  * @author daniel.hartwich
  * @author serj.lotutovici
  */
-public final class ContactsResource extends Resource {
+public class ContactsResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     ContactsResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/JobsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/JobsResource.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @author daniel.hartwich
  * @author cristian.monforte
  */
-public final class JobsResource extends Resource {
+public class JobsResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     JobsResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/MessagesResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/MessagesResource.java
@@ -30,7 +30,7 @@ import java.util.List;
  * <p>
  * Provides methods which allow access to user's {@linkplain Conversation conversations}.
  */
-public final class MessagesResource extends Resource {
+public class MessagesResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     MessagesResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/MiscellaneousResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/MiscellaneousResource.java
@@ -32,7 +32,7 @@ import static com.squareup.moshi.Types.newParameterizedType;
  *
  * @author daniel.hartwich
  */
-public final class MiscellaneousResource extends Resource {
+public class MiscellaneousResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     MiscellaneousResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/ProfileEditingResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ProfileEditingResource.java
@@ -45,7 +45,7 @@ import java.util.List;
  * @author daniel.hartwich
  * @author serj.lotutovici
  */
-public final class ProfileEditingResource extends Resource {
+public class ProfileEditingResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     ProfileEditingResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/ProfileVisitsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ProfileVisitsResource.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @author daniel.hartwich
  */
-public final class ProfileVisitsResource extends Resource {
+public class ProfileVisitsResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     ProfileVisitsResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/RecommendationsResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/RecommendationsResource.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @author daniel.hartwich
  */
-public final class RecommendationsResource extends Resource {
+public class RecommendationsResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     RecommendationsResource(XingApi api) {
         super(api);

--- a/api-client/src/main/java/com/xing/api/resources/UserProfilesResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/UserProfilesResource.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @author serj.lotutovici
  * @author daniel.hartwich
  */
-public final class UserProfilesResource extends Resource {
+public class UserProfilesResource extends Resource {
     /** Creates a resource instance. This should be the only constructor declared by child classes. */
     UserProfilesResource(XingApi api) {
         super(api);

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -469,6 +469,19 @@ public class CallSpecTest {
     }
 
     @Test
+    public void specHandlesSuccessResponseAsStringIfResponseIsVoid() throws Exception {
+        server.enqueue(new MockResponse().setBody(new Buffer()));
+
+        CallSpec<String, Object> spec = this.<String, Object>builder(HttpMethod.POST, "/", false)
+              .responseAs(Void.class)
+              .build();
+
+        Response<String, Object> response = spec.execute();
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isNull();
+    }
+
+    @Test
     public void specHandlesSuccessResponseAsResponseBody() throws Exception {
         server.enqueue(new MockResponse().setBody("Testing"));
 

--- a/api-client/src/test/java/com/xing/api/resources/MessagesResourceTest.java
+++ b/api-client/src/test/java/com/xing/api/resources/MessagesResourceTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import static com.xing.api.TestUtils.file;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
 
 /**
  * Test each resource method against a valid json object. This test is a minimal safety major to ensure that each
@@ -43,7 +42,7 @@ public final class MessagesResourceTest extends ResourceTestCase<MessagesResourc
     public void getConversationsByUserId() throws Exception {
         server.enqueue(new MockResponse().setBody(file("list_of_conversations.json")));
 
-        Response<List<Conversation>, HttpError> response = resource.getConversationsByUserId(anyString()).execute();
+        Response<List<Conversation>, HttpError> response = resource.getConversationsByUserId("").execute();
         assertThat(response.body().size()).isEqualTo(2);
     }
 
@@ -51,9 +50,7 @@ public final class MessagesResourceTest extends ResourceTestCase<MessagesResourc
     public void createConversation() throws Exception {
         server.enqueue(new MockResponse().setBody(file("conversation.json")));
 
-        Response<Conversation, HttpError> response =
-              resource.createConversation(anyString(), anyString(), anyString(), anyString()).execute();
-
+        Response<Conversation, HttpError> response = resource.createConversation("", "", "", "").execute();
         assertThat(response.body().subject()).isEqualTo("The subject!");
     }
 
@@ -61,9 +58,7 @@ public final class MessagesResourceTest extends ResourceTestCase<MessagesResourc
     public void sendMessageToConversation() throws Exception {
         server.enqueue(new MockResponse().setBody(file("conversation_message.json")));
 
-        Response<ConversationMessage, HttpError> response =
-              resource.sendMessageToConversation(anyString(), anyString(), anyString()).execute();
-
+        Response<ConversationMessage, HttpError> response = resource.sendMessageToConversation("", "", "").execute();
         assertThat(response.body().content()).isEqualTo("New message");
     }
 }

--- a/api-client/src/test/java/com/xing/api/resources/ResourceTestCase.java
+++ b/api-client/src/test/java/com/xing/api/resources/ResourceTestCase.java
@@ -62,6 +62,7 @@ public class ResourceTestCase<T extends Resource> {
     private void validateResource() throws Exception {
         // All public methods must return a call spec.
         Method[] methods = resourceClass.getDeclaredMethods();
+        //noinspection SSBasedInspection
         for (Method method : methods) {
             if (Modifier.isPublic(method.getModifiers())) {
                 Class<?> returnType = method.getReturnType();


### PR DESCRIPTION
At this point we put all responsability on the user to not abuse the
resource classes. Since the main concept behind the Resource classes is
namespace bassed, we don't need to care if the class is final or not.
This also alow to mock resources on the consumer side, wich is a good
thing for testing.
