### PR TITLE
Make CallSpec an interface.

### DIFF
--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -17,8 +17,6 @@
 package com.xing.api;
 
 import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.JsonReader;
-import com.squareup.moshi.Types;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -27,299 +25,128 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.ResponseBody;
 import okio.Buffer;
-import okio.BufferedSource;
-import okio.ForwardingSource;
-import okio.Okio;
 import rx.Observable;
-import rx.Observable.Operator;
-import rx.Producer;
-import rx.Subscriber;
-import rx.Subscription;
-import rx.exceptions.Exceptions;
-import rx.functions.Func1;
 
 import static com.xing.api.UrlEscapeUtils.escape;
 import static com.xing.api.Utils.assertionError;
-import static com.xing.api.Utils.buffer;
 import static com.xing.api.Utils.checkNotNull;
-import static com.xing.api.Utils.closeQuietly;
 import static com.xing.api.Utils.stateError;
 import static com.xing.api.Utils.stateNotNull;
 
 /**
- * TODO docs.
+ * An invocation of a {@linkplain Resource resource method} that sends a request to XWS and returns a response.
+ * Each call yields its own HTTP request and response pair. Use {@link #clone} to make multiple
+ * calls with the same parameters to the same {@linkplain Resource resource call}; this may be used to implement polling or
+ * to retry a failed call.
  *
- * @author serj.lotutovici
+ * <p>Calls may be executed synchronously with {@link #execute}, asynchronously with {@link
+ * #enqueue}, or as asynchronous observable streams with {@link #stream()} or {@link #rawStream()} (<b>Note:</b> that a
+ * dependency to RxJava is required). In either case the call can be canceled at any time with {@link #cancel}. A call that
+ * is busy writing its request or reading its response may receive a {@link IOException}; this is working as designed.
+ *
+ * @param <RT> Successful response body type.
+ * @param <ET> Error response body type.
  */
-public final class CallSpec<RT, ET> implements Cloneable {
-    private final XingApi api;
-    private final Builder<RT, ET> builder;
-    private final Type responseType;
-    private final Type errorType;
-
-    private volatile Call rawCall;
-    private boolean executed; // Guarded by this.
-    private volatile boolean canceled;
-
-    private CallSpec(Builder<RT, ET> builder) {
-        this.builder = builder;
-        api = builder.api;
-        responseType = builder.responseType;
-        errorType = builder.errorType;
-    }
-
-    @SuppressWarnings("CloneDoesntCallSuperClone") // This is a final type & this saves clearing state.
-    @Override
-    public CallSpec<RT, ET> clone() {
-        // When called from CallSpec we don't need to go through the validation process.
-        return new CallSpec<>(builder.newBuilder());
-    }
-
+public interface CallSpec<RT, ET> extends Cloneable {
     /**
      * Synchronously executes the request and returns it's response.
      *
      * @throws IOException If a problem occurred while talking to the server.
      * @throws RuntimeException If an unexpected error occurred during execution or while parsing response.
      */
-    public Response<RT, ET> execute() throws IOException {
-        synchronized (this) {
-            if (executed) throw stateError("Call already executed");
-            executed = true;
-        }
-
-        Call rawCall = createRawCall();
-        if (canceled) rawCall.cancel();
-        this.rawCall = rawCall;
-
-        return parseResponse(rawCall.execute());
-    }
+    Response<RT, ET> execute() throws IOException;
 
     /**
      * Asynchronously send the request and notify {@code callback} of its response or if an error
      * occurred talking to the server, creating the request, or processing the response.
-     * <p>
-     * This method is <i>null-safe</i>, which means that there will be no failure or error propagated if
+     *
+     * <p>This method is <i>null-safe</i>, which means that there will be no failure or error propagated if
      * {@code callback} methods will throw an error.
-     * <p>
-     * Note that the {@code callback} will be dropped after the call execution.
+     *
+     * <p>Note that the {@code callback} will be dropped after the call execution.
      */
-    public void enqueue(final Callback<RT, ET> callback) {
-        synchronized (this) {
-            if (executed) throw stateError("Call already executed");
-            executed = true;
-        }
-
-        Call rawCall = createRawCall();
-        if (canceled) rawCall.cancel();
-        this.rawCall = rawCall;
-
-        rawCall.enqueue(new okhttp3.Callback() {
-            private void callFailure(Throwable e) {
-                try {
-                    api.callbackAdapter().adapt(callback).onFailure(e);
-                } catch (Throwable t) {
-                    // TODO add some logging
-                }
-            }
-
-            private void callSuccess(Response<RT, ET> response) {
-                try {
-                    api.callbackAdapter().adapt(callback).onResponse(response);
-                } catch (Throwable t) {
-                    // TODO add some logging
-                }
-            }
-
-            @Override
-            public void onFailure(Call call, IOException e) {
-                callFailure(e);
-            }
-
-            @Override
-            public void onResponse(Call call, okhttp3.Response rawResponse) {
-                Response<RT, ET> response;
-                try {
-                    response = parseResponse(rawResponse);
-                } catch (Throwable e) {
-                    callFailure(e);
-                    return;
-                }
-                callSuccess(response);
-            }
-        });
-    }
+    void enqueue(Callback<RT, ET> callback);
 
     /**
      * Executes the underlying call as an observable. The observable will try to return an
      * {@link Response} object from which the http result may be obtained.
      */
-    public Observable<Response<RT, ET>> rawStream() {
-        return Observable.create(new SpecOnSubscribe<>(this));
-    }
+    Observable<Response<RT, ET>> rawStream();
 
     /**
      * Executes the underlying call as an observable. This method will try to populate the success response object of
      * a {@link Response}. In case of an error an {@link HttpException} will be thrown.
      * For a more richer and controllable api consider calling {@link #rawStream()}.
      */
-    public Observable<RT> stream() {
-        return rawStream().lift(OperatorMapResponseToBodyOrError.<RT, ET>instance());
-    }
+    Observable<RT> stream();
 
     /**
      * Returns true if this call has been either {@linkplain #execute() executed} or {@linkplain #enqueue(Callback)
      * enqueued}. It is an error to execute or enqueue a call more than once.
      */
-    public synchronized boolean isExecuted() {
-        return executed;
-    }
+    boolean isExecuted();
 
     /** True if {@link #cancel()} was called. */
-    public boolean isCanceled() {
-        return canceled;
-    }
+    boolean isCanceled();
 
     /**
      * Cancel this call. An attempt will be made to cancel in-flight calls, and if the call has not yet been executed
      * it never will be.
      */
-    public void cancel() {
-        canceled = true;
-        Call rawCall = this.rawCall;
-        if (rawCall != null) rawCall.cancel();
-    }
+    void cancel();
 
-    public CallSpec<RT, ET> queryParam(String name, Object value) {
-        builder.queryParam(name, value);
-        return this;
-    }
+    /** Appends a query parameter to the query string of the underlying request's url. */
+    CallSpec<RT, ET> queryParam(String name, Object value);
 
-    public CallSpec<RT, ET> queryParam(String name, String value) {
-        builder.queryParam(name, value);
-        return this;
-    }
+    /** Appends a query parameter to the query string of the underlying request's url. */
+    CallSpec<RT, ET> queryParam(String name, String value);
 
-    public CallSpec<RT, ET> queryParam(String name, String... values) {
-        builder.queryParam(name, values);
-        return this;
-    }
+    /** Appends a query parameter as a csv list to the query string of the underlying request's url. */
+    CallSpec<RT, ET> queryParam(String name, String... values);
 
-    public CallSpec<RT, ET> queryParam(String name, List<String> values) {
-        builder.queryParam(name, values);
-        return this;
-    }
+    /** Appends a query parameter as a csv list to the query string of the underlying request's url. */
+    CallSpec<RT, ET> queryParam(String name, List<String> values);
 
-    public CallSpec<RT, ET> formField(String name, String value) {
-        builder.formField(name, value);
-        return this;
-    }
+    /**
+     * Adds a form field to the underlying request's form body.
+     *
+     * <p>This will throw an {@linkplain NullPointerException} if the form body supprt was not specified during spec
+     * creation.
+     */
+    CallSpec<RT, ET> formField(String name, String value);
 
-    public CallSpec<RT, ET> formField(String name, String... values) {
-        builder.formField(name, values);
-        return this;
-    }
+    /**
+     * Adds a form field as a csv list to the underlying request's form body.
+     *
+     * <p>This will throw an {@linkplain NullPointerException} if the form body supprt was not specified during spec
+     * creation.
+     */
+    CallSpec<RT, ET> formField(String name, String... values);
 
-    public CallSpec<RT, ET> formField(String name, List<String> values) {
-        builder.formField(name, values);
-        return this;
-    }
+    /**
+     * Adds a form field as a csv list to the underlying request's form body.
+     *
+     * <p>This will throw an {@linkplain NullPointerException} if the form body supprt was not specified during spec
+     * creation.
+     */
+    CallSpec<RT, ET> formField(String name, List<String> values);
 
-    /** Returns a raw {@link Call} pre-building the targeted request. */
-    private Call createRawCall() {
-        return api.client().newCall(builder.request());
-    }
-
-    /** Parsers the OkHttp raw response and returns an response ready to be consumed by the caller. */
-    @SuppressWarnings("MagicNumber") // These codes are specific to this method and to the http protocol.
-    private Response<RT, ET> parseResponse(okhttp3.Response rawResponse) throws IOException {
-        ResponseBody rawBody = rawResponse.body();
-
-        // Remove the body's source (the only stateful object) so we can pass the response along.
-        rawResponse = rawResponse.newBuilder()
-              .body(new NoContentResponseBody(rawBody.contentType(), rawBody.contentLength()))
-              .build();
-
-        ExceptionCatchingRequestBody catchingBody = new ExceptionCatchingRequestBody(rawBody);
-        int code = rawResponse.code();
-        if (code < 200 || code >= 300) {
-            try {
-
-                // Bypass the body parsing, and return the raw data.
-                if (code == 401) {
-                    ResponseBody bufferedBody = buffer(catchingBody);
-                    api.notifyAuthError(Response.error(bufferedBody, rawResponse));
-                    throw new IOException("401 Unauthorized");
-                }
-
-                // Buffer the entire body to avoid future I/O.
-                ET errorBody = parseBody(errorType, catchingBody);
-                return Response.error(errorBody, rawResponse);
-            } catch (RuntimeException e) {
-                // If the underlying source threw an exception, propagate that, rather than indicating it was
-                // a runtime exception.
-                catchingBody.throwIfCaught();
-                throw e;
-            } finally {
-                // FIXME I don't think we need to close the body twice.
-                closeQuietly(catchingBody);
-            }
-        }
-
-        // No need to parse the response body since the response should not contain any content.
-        if (code == 204 || code == 205) {
-            return Response.success(null, rawResponse);
-        }
-
-        try {
-            RT body = parseBody(responseType, catchingBody);
-            String contentRange = rawResponse.header(ContentRange.HEADER_NAME);
-            return Response.success(body, ContentRange.parse(contentRange), rawResponse);
-        } catch (RuntimeException e) {
-            // If the underlying source threw an exception, propagate that, rather than indicating it was
-            // a runtime exception.
-            catchingBody.throwIfCaught();
-            throw e;
-        } finally {
-            // FIXME I don't think we need to close the body twice.
-            closeQuietly(catchingBody);
-        }
-    }
-
-    @SuppressWarnings("unchecked") // Type is declared on CallSpec creation. Type matching is the caller responsibility.
-    private <PT> PT parseBody(Type type, ResponseBody body) throws IOException {
-        if (body == null) return null;
-
-        try {
-            // Don't parse the response body, if the caller doesn't expect a json.
-            Class<?> rawType = Types.getRawType(type);
-            if (rawType == Void.class) return null;
-            if (rawType == String.class) return (PT) body.string();
-            if (rawType == ResponseBody.class) return (PT) buffer(body);
-
-            JsonAdapter<PT> adapter = api.converter().adapter(type);
-            JsonReader reader = JsonReader.of(body.source());
-            return adapter.fromJson(reader);
-        } finally {
-            closeQuietly(body);
-        }
-    }
+    /** Creates and returns a copy of <strong>this</strong> object losing the executable state. */
+    CallSpec<RT, ET> clone();
 
     /**
      * TODO docs.
      */
-    public static final class Builder<RT, ET> {
+    final class Builder<RT, ET> {
         // Upper and lower characters, digits, underscores, and hyphens, starting with a character.
         private static final String PARAM = "[a-zA-Z][a-zA-Z0-9_-]*";
         private static final Pattern PARAM_NAME_REGEX = Pattern.compile(PARAM);
@@ -334,7 +161,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
         private String resourcePath;
 
         private HttpUrl.Builder urlBuilder;
-        private FormBody.Builder formEncodingBuilder;
+        private FormBody.Builder formBodyBuilder;
         private RequestBody body;
 
         final XingApi api;
@@ -351,7 +178,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
             apiEndpoint = api.apiEndpoint();
             requestBuilder = new Request.Builder().header("Accept", "application/json");
 
-            if (isFormEncoded) formEncodingBuilder = new FormBody.Builder();
+            if (isFormEncoded) formBodyBuilder = new FormBody.Builder();
         }
 
         private Builder(Builder<RT, ET> builder) {
@@ -362,7 +189,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
             resourcePathParams = builder.resourcePathParams;
             resourcePath = builder.resourcePath;
             urlBuilder = builder.urlBuilder;
-            formEncodingBuilder = builder.formEncodingBuilder;
+            formBodyBuilder = builder.formBodyBuilder;
             body = builder.body;
             responseType = builder.responseType;
             errorType = builder.errorType;
@@ -375,8 +202,8 @@ public final class CallSpec<RT, ET> implements Cloneable {
 
         /**
          * Replaces path parameter {@code name} with provided {@code values}.
-         * <p>
-         * The string values will not be 'escaped' to meet the url formatting. If required this action has to be
+         *
+         * <p>The string values will not be 'escaped' to meet the url formatting. If required this action has to be
          * performed by the caller before submitting the values.
          */
         public Builder<RT, ET> pathParam(String name, String... values) {
@@ -385,8 +212,8 @@ public final class CallSpec<RT, ET> implements Cloneable {
 
         /**
          * Replaces path parameter {@code name} with provided {@code values}.
-         * <p>
-         * The string values will not be 'escaped' to meet the url formatting. If required this action has to be
+         *
+         * <p>The string values will not be 'escaped' to meet the url formatting. If required this action has to be
          * performed by the caller before submitting the values.
          */
         public Builder<RT, ET> pathParam(String name, List<String> values) {
@@ -416,8 +243,8 @@ public final class CallSpec<RT, ET> implements Cloneable {
         }
 
         public Builder<RT, ET> formField(String name, Object value) {
-            stateNotNull(formEncodingBuilder, "form fields are not accepted by this request.");
-            formEncodingBuilder.add(name, String.valueOf(value));
+            stateNotNull(formBodyBuilder, "form fields are not accepted by this request.");
+            formBodyBuilder.add(name, String.valueOf(value));
             return this;
         }
 
@@ -477,7 +304,7 @@ public final class CallSpec<RT, ET> implements Cloneable {
             if (responseType == null) throw stateError("Response type is not set.");
             if (errorType == null) errorType = HttpError.class;
 
-            return new CallSpec<>(this);
+            return new RealCallSpec<>(this);
         }
 
         Request request() {
@@ -487,8 +314,8 @@ public final class CallSpec<RT, ET> implements Cloneable {
             RequestBody body = this.body;
             if (body == null) {
                 // Try to pull from one of the builders.
-                if (formEncodingBuilder != null) {
-                    body = formEncodingBuilder.build();
+                if (formBodyBuilder != null) {
+                    body = formBodyBuilder.build();
                 } else if (httpMethod.hasBody()) {
                     // Body is absent, make an empty body.
                     //noinspection ZeroLengthArrayAllocation
@@ -550,11 +377,11 @@ public final class CallSpec<RT, ET> implements Cloneable {
         /**
          * Converts a list into a string with coma separated values. If the list is {@code null} or empty an
          * empty string will be returned.
-         * <p>
-         * <b>NOTE:</b> The values contained in the {@link List} should not be null, otherwise a {@code "null"}
+         *
+         * <p><b>NOTE:</b> The values contained in the {@link List} should not be null, otherwise a {@code "null"}
          * will be put in it's place.
-         * <p>
-         * <b>NOTE:</b> For path params we need to avoid the whitespace after the comma, otherwise the url will be
+         *
+         * <p><b>NOTE:</b> For path params we need to avoid the whitespace after the comma, otherwise the url will be
          * considered as malformed.
          */
         static String toCsv(List<?> values, boolean withSpace) {
@@ -576,188 +403,6 @@ public final class CallSpec<RT, ET> implements Cloneable {
                 }
             }
             return sb.toString();
-        }
-    }
-
-    static final class NoContentResponseBody extends ResponseBody {
-        private final MediaType contentType;
-        private final long contentLength;
-
-        NoContentResponseBody(MediaType contentType, long contentLength) {
-            this.contentType = contentType;
-            this.contentLength = contentLength;
-        }
-
-        @Override
-        public MediaType contentType() {
-            return contentType;
-        }
-
-        @Override
-        public long contentLength() {
-            return contentLength;
-        }
-
-        @Override
-        public BufferedSource source() {
-            throw new IllegalStateException("Cannot read raw response body of a parsed body.");
-        }
-    }
-
-    static final class ExceptionCatchingRequestBody extends ResponseBody {
-        private final ResponseBody delegate;
-        private IOException thrownException;
-
-        ExceptionCatchingRequestBody(ResponseBody delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public MediaType contentType() {
-            return delegate.contentType();
-        }
-
-        @Override
-        public long contentLength() {
-            return delegate.contentLength();
-        }
-
-        @Override
-        public BufferedSource source() {
-            BufferedSource delegateSource = delegate.source();
-            return Okio.buffer(new ForwardingSource(delegateSource) {
-                @Override
-                public long read(Buffer sink, long byteCount) throws IOException {
-                    try {
-                        return super.read(sink, byteCount);
-                    } catch (IOException e) {
-                        thrownException = e;
-                        throw e;
-                    }
-                }
-            });
-        }
-
-        @Override
-        public void close() {
-            delegate.close();
-        }
-
-        void throwIfCaught() throws IOException {
-            if (thrownException != null) throw thrownException;
-        }
-    }
-
-    /**
-     * {@link Observable.OnSubscribe} implementation that takes a {@linkplain CallSpec spec} and executes the request.
-     * This class handles the subscriptions life cycle and completes the subscription as soon as the response is
-     * delivered.
-     */
-    static final class SpecOnSubscribe<RT, ET> implements Observable.OnSubscribe<Response<RT, ET>> {
-        private final CallSpec<RT, ET> originalSpec;
-
-        /** Creates on instance of {@linkplain SpecOnSubscribe} for the provided spec. */
-        SpecOnSubscribe(CallSpec<RT, ET> originalSpec) {
-            this.originalSpec = originalSpec;
-        }
-
-        @Override
-        public void call(Subscriber<? super Response<RT, ET>> subscriber) {
-            // Since Call is a one-shot type, clone it for each new subscriber.
-            CallSpec<RT, ET> spec = originalSpec.clone();
-
-            // Wrap the call in a helper which handles both unsubscription and backpressure.
-            RequestArbiter<RT, ET> requestArbiter = new RequestArbiter<>(spec, subscriber);
-            subscriber.add(requestArbiter);
-            subscriber.setProducer(requestArbiter);
-        }
-    }
-
-    /** Helper/Arbiter that will honor request back-pressure on observable creation. */
-    static final class RequestArbiter<RT, ET> extends AtomicBoolean implements Subscription, Producer {
-        private final CallSpec<RT, ET> spec;
-        private final Subscriber<? super Response<RT, ET>> subscriber;
-
-        /** Creates an instance of {@linkplain RequestArbiter} for the provided spec and subscriber. */
-        RequestArbiter(CallSpec<RT, ET> spec, Subscriber<? super Response<RT, ET>> subscriber) {
-            this.spec = spec;
-            this.subscriber = subscriber;
-        }
-
-        @Override
-        public void request(long n) {
-            if (n < 0) throw new IllegalArgumentException("n < 0: " + n);
-            if (n == 0) return; // Nothing to do when requesting 0.
-            if (!compareAndSet(false, true)) return; // Request was already triggered.
-
-            try {
-                Response<RT, ET> response = spec.execute();
-                if (!subscriber.isUnsubscribed()) {
-                    subscriber.onNext(response);
-                }
-            } catch (Throwable t) {
-                Exceptions.throwIfFatal(t);
-                if (!subscriber.isUnsubscribed()) {
-                    subscriber.onError(t);
-                }
-                return;
-            }
-
-            if (!subscriber.isUnsubscribed()) {
-                subscriber.onCompleted();
-            }
-        }
-
-        @Override
-        public void unsubscribe() {
-            spec.cancel();
-        }
-
-        @Override
-        public boolean isUnsubscribed() {
-            return spec.isCanceled();
-        }
-    }
-
-    /**
-     * A version of {@link Observable#map(Func1)} which lets us trigger {@code onError} without having
-     * to use {@link Observable#flatMap(Func1)} which breaks producer requests from propagating.
-     */
-    static final class OperatorMapResponseToBodyOrError<RT, ET> implements Operator<RT, Response<RT, ET>> {
-        private static final OperatorMapResponseToBodyOrError<Object, Object> INSTANCE =
-              new OperatorMapResponseToBodyOrError<>();
-
-        /**
-         * Returns a static instance of {@linkplain OperatorMapResponseToBodyOrError}.
-         * This allows us to avoid multiple instantiations for each request (saves memory).
-         */
-        @SuppressWarnings("unchecked") // Safe because of erasure.
-        static <RT, ET> OperatorMapResponseToBodyOrError<RT, ET> instance() {
-            return (OperatorMapResponseToBodyOrError<RT, ET>) INSTANCE;
-        }
-
-        @Override
-        public Subscriber<? super Response<RT, ET>> call(final Subscriber<? super RT> child) {
-            return new Subscriber<Response<RT, ET>>(child) {
-                @Override
-                public void onNext(Response<RT, ET> response) {
-                    if (response.isSuccessful()) {
-                        child.onNext(response.body());
-                    } else {
-                        child.onError(new HttpException(response));
-                    }
-                }
-
-                @Override
-                public void onCompleted() {
-                    child.onCompleted();
-                }
-
-                @Override
-                public void onError(Throwable th) {
-                    child.onError(th);
-                }
-            };
         }
     }
 }

--- a/api-client/src/main/java/com/xing/api/RealCallSpec.java
+++ b/api-client/src/main/java/com/xing/api/RealCallSpec.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright (C) 2016 XING AG (http://xing.com/)
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.Types;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ForwardingSource;
+import okio.Okio;
+import rx.Observable;
+import rx.Observable.Operator;
+import rx.Producer;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.exceptions.Exceptions;
+import rx.functions.Func1;
+
+import static com.xing.api.Utils.buffer;
+import static com.xing.api.Utils.closeQuietly;
+import static com.xing.api.Utils.stateError;
+
+/** Implements {@linkplain CallSpec} providing the desired functionality. */
+final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
+    private final XingApi api;
+    private final CallSpec.Builder<RT, ET> builder;
+    private final Type responseType;
+    private final Type errorType;
+
+    private volatile Call rawCall;
+    private boolean executed; // Guarded by this.
+    private volatile boolean canceled;
+
+    RealCallSpec(CallSpec.Builder<RT, ET> builder) {
+        this.builder = builder;
+        api = builder.api;
+        responseType = builder.responseType;
+        errorType = builder.errorType;
+    }
+
+    @SuppressWarnings("CloneDoesntCallSuperClone") // This is a final type & this saves clearing state.
+    @Override
+    public CallSpec<RT, ET> clone() {
+        // When called from CallSpec we don't need to go through the validation process.
+        return new RealCallSpec<>(builder.newBuilder());
+    }
+
+    @Override
+    public Response<RT, ET> execute() throws IOException {
+        synchronized (this) {
+            if (executed) throw stateError("Call already executed");
+            executed = true;
+        }
+
+        Call rawCall = createRawCall();
+        if (canceled) rawCall.cancel();
+        this.rawCall = rawCall;
+
+        return parseResponse(rawCall.execute());
+    }
+
+    @Override
+    public void enqueue(final Callback<RT, ET> callback) {
+        synchronized (this) {
+            if (executed) throw stateError("Call already executed");
+            executed = true;
+        }
+
+        Call rawCall = createRawCall();
+        if (canceled) rawCall.cancel();
+        this.rawCall = rawCall;
+
+        rawCall.enqueue(new okhttp3.Callback() {
+            private void callFailure(Throwable e) {
+                try {
+                    api.callbackAdapter().adapt(callback).onFailure(e);
+                } catch (Throwable t) {
+                    // TODO add some logging
+                }
+            }
+
+            private void callSuccess(Response<RT, ET> response) {
+                try {
+                    api.callbackAdapter().adapt(callback).onResponse(response);
+                } catch (Throwable t) {
+                    // TODO add some logging
+                }
+            }
+
+            @Override
+            public void onFailure(Call call, IOException e) {
+                callFailure(e);
+            }
+
+            @Override
+            public void onResponse(Call call, okhttp3.Response rawResponse) {
+                Response<RT, ET> response;
+                try {
+                    response = parseResponse(rawResponse);
+                } catch (Throwable e) {
+                    callFailure(e);
+                    return;
+                }
+                callSuccess(response);
+            }
+        });
+    }
+
+    @Override
+    public Observable<Response<RT, ET>> rawStream() {
+        return Observable.create(new SpecOnSubscribe<>(this));
+    }
+
+    @Override
+    public Observable<RT> stream() {
+        return rawStream().lift(OperatorMapResponseToBodyOrError.<RT, ET>instance());
+    }
+
+    @Override
+    public synchronized boolean isExecuted() {
+        return executed;
+    }
+
+    @Override
+    public boolean isCanceled() {
+        return canceled;
+    }
+
+    @Override
+    public void cancel() {
+        canceled = true;
+        Call rawCall = this.rawCall;
+        if (rawCall != null) rawCall.cancel();
+    }
+
+    @Override
+    public CallSpec<RT, ET> queryParam(String name, Object value) {
+        builder.queryParam(name, value);
+        return this;
+    }
+
+    @Override
+    public CallSpec<RT, ET> queryParam(String name, String value) {
+        builder.queryParam(name, value);
+        return this;
+    }
+
+    @Override
+    public CallSpec<RT, ET> queryParam(String name, String... values) {
+        builder.queryParam(name, values);
+        return this;
+    }
+
+    @Override
+    public CallSpec<RT, ET> queryParam(String name, List<String> values) {
+        builder.queryParam(name, values);
+        return this;
+    }
+
+    @Override
+    public CallSpec<RT, ET> formField(String name, String value) {
+        builder.formField(name, value);
+        return this;
+    }
+
+    @Override
+    public CallSpec<RT, ET> formField(String name, String... values) {
+        builder.formField(name, values);
+        return this;
+    }
+
+    @Override
+    public CallSpec<RT, ET> formField(String name, List<String> values) {
+        builder.formField(name, values);
+        return this;
+    }
+
+    /** Returns a raw {@link Call} pre-building the targeted request. */
+    private Call createRawCall() {
+        return api.client().newCall(builder.request());
+    }
+
+    /** Parsers the OkHttp raw response and returns an response ready to be consumed by the caller. */
+    @SuppressWarnings("MagicNumber") // These codes are specific to this method and to the http protocol.
+    private Response<RT, ET> parseResponse(okhttp3.Response rawResponse) throws IOException {
+        ResponseBody rawBody = rawResponse.body();
+
+        // Remove the body's source (the only stateful object) so we can pass the response along.
+        rawResponse = rawResponse.newBuilder()
+              .body(new NoContentResponseBody(rawBody.contentType(), rawBody.contentLength()))
+              .build();
+
+        ExceptionCatchingRequestBody catchingBody = new ExceptionCatchingRequestBody(rawBody);
+        int code = rawResponse.code();
+        if (code < 200 || code >= 300) {
+            try {
+
+                // Bypass the body parsing, and return the raw data.
+                if (code == 401) {
+                    ResponseBody bufferedBody = buffer(catchingBody);
+                    api.notifyAuthError(Response.error(bufferedBody, rawResponse));
+                    throw new IOException("401 Unauthorized");
+                }
+
+                // Buffer the entire body to avoid future I/O.
+                ET errorBody = parseBody(errorType, catchingBody);
+                return Response.error(errorBody, rawResponse);
+            } catch (RuntimeException e) {
+                // If the underlying source threw an exception, propagate that, rather than indicating it was
+                // a runtime exception.
+                catchingBody.throwIfCaught();
+                throw e;
+            } finally {
+                // FIXME I don't think we need to close the body twice.
+                closeQuietly(catchingBody);
+            }
+        }
+
+        // No need to parse the response body since the response should not contain any content.
+        if (code == 204 || code == 205) {
+            return Response.success(null, rawResponse);
+        }
+
+        try {
+            RT body = parseBody(responseType, catchingBody);
+            String contentRange = rawResponse.header(ContentRange.HEADER_NAME);
+            return Response.success(body, ContentRange.parse(contentRange), rawResponse);
+        } catch (RuntimeException e) {
+            // If the underlying source threw an exception, propagate that, rather than indicating it was
+            // a runtime exception.
+            catchingBody.throwIfCaught();
+            throw e;
+        } finally {
+            // FIXME I don't think we need to close the body twice.
+            closeQuietly(catchingBody);
+        }
+    }
+
+    @SuppressWarnings("unchecked") // Type is declared on CallSpec creation. Type matching is the caller responsibility.
+    private <PT> PT parseBody(Type type, ResponseBody body) throws IOException {
+        if (body == null) return null;
+
+        try {
+            // Don't parse the response body, if the caller doesn't expect a json.
+            Class<?> rawType = Types.getRawType(type);
+            if (rawType == Void.class) return null;
+            if (rawType == String.class) return (PT) body.string();
+            if (rawType == ResponseBody.class) return (PT) buffer(body);
+
+            JsonAdapter<PT> adapter = api.converter().adapter(type);
+            JsonReader reader = JsonReader.of(body.source());
+            return adapter.fromJson(reader);
+        } finally {
+            closeQuietly(body);
+        }
+    }
+
+    static final class NoContentResponseBody extends ResponseBody {
+        private final MediaType contentType;
+        private final long contentLength;
+
+        NoContentResponseBody(MediaType contentType, long contentLength) {
+            this.contentType = contentType;
+            this.contentLength = contentLength;
+        }
+
+        @Override
+        public MediaType contentType() {
+            return contentType;
+        }
+
+        @Override
+        public long contentLength() {
+            return contentLength;
+        }
+
+        @Override
+        public BufferedSource source() {
+            throw new IllegalStateException("Cannot read raw response body of a parsed body.");
+        }
+    }
+
+    static final class ExceptionCatchingRequestBody extends ResponseBody {
+        private final ResponseBody delegate;
+        private IOException thrownException;
+
+        ExceptionCatchingRequestBody(ResponseBody delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public MediaType contentType() {
+            return delegate.contentType();
+        }
+
+        @Override
+        public long contentLength() {
+            return delegate.contentLength();
+        }
+
+        @Override
+        public BufferedSource source() {
+            BufferedSource delegateSource = delegate.source();
+            return Okio.buffer(new ForwardingSource(delegateSource) {
+                @Override
+                public long read(Buffer sink, long byteCount) throws IOException {
+                    try {
+                        return super.read(sink, byteCount);
+                    } catch (IOException e) {
+                        thrownException = e;
+                        throw e;
+                    }
+                }
+            });
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+
+        void throwIfCaught() throws IOException {
+            if (thrownException != null) throw thrownException;
+        }
+    }
+
+    /**
+     * {@link Observable.OnSubscribe} implementation that takes a {@linkplain CallSpec spec} and executes the request.
+     * This class handles the subscriptions life cycle and completes the subscription as soon as the response is
+     * delivered.
+     */
+    static final class SpecOnSubscribe<RT, ET> implements Observable.OnSubscribe<Response<RT, ET>> {
+        private final CallSpec<RT, ET> originalSpec;
+
+        /** Creates on instance of {@linkplain SpecOnSubscribe} for the provided spec. */
+        SpecOnSubscribe(CallSpec<RT, ET> originalSpec) {
+            this.originalSpec = originalSpec;
+        }
+
+        @Override
+        public void call(Subscriber<? super Response<RT, ET>> subscriber) {
+            // Since Call is a one-shot type, clone it for each new subscriber.
+            CallSpec<RT, ET> spec = originalSpec.clone();
+
+            // Wrap the call in a helper which handles both unsubscription and backpressure.
+            RequestArbiter<RT, ET> requestArbiter = new RequestArbiter<>(spec, subscriber);
+            subscriber.add(requestArbiter);
+            subscriber.setProducer(requestArbiter);
+        }
+    }
+
+    /** Helper/Arbiter that will honor request back-pressure on observable creation. */
+    static final class RequestArbiter<RT, ET> extends AtomicBoolean implements Subscription, Producer {
+        private final CallSpec<RT, ET> spec;
+        private final Subscriber<? super Response<RT, ET>> subscriber;
+
+        /** Creates an instance of {@linkplain RequestArbiter} for the provided spec and subscriber. */
+        RequestArbiter(CallSpec<RT, ET> spec, Subscriber<? super Response<RT, ET>> subscriber) {
+            this.spec = spec;
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n < 0) throw new IllegalArgumentException("n < 0: " + n);
+            if (n == 0) return; // Nothing to do when requesting 0.
+            if (!compareAndSet(false, true)) return; // Request was already triggered.
+
+            try {
+                Response<RT, ET> response = spec.execute();
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onNext(response);
+                }
+            } catch (Throwable t) {
+                Exceptions.throwIfFatal(t);
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onError(t);
+                }
+                return;
+            }
+
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onCompleted();
+            }
+        }
+
+        @Override
+        public void unsubscribe() {
+            spec.cancel();
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return spec.isCanceled();
+        }
+    }
+
+    /**
+     * A version of {@link Observable#map(Func1)} which lets us trigger {@code onError} without having
+     * to use {@link Observable#flatMap(Func1)} which breaks producer requests from propagating.
+     */
+    static final class OperatorMapResponseToBodyOrError<RT, ET> implements Operator<RT, Response<RT, ET>> {
+        private static final OperatorMapResponseToBodyOrError<Object, Object> INSTANCE =
+              new OperatorMapResponseToBodyOrError<>();
+
+        /**
+         * Returns a static instance of {@linkplain OperatorMapResponseToBodyOrError}.
+         * This allows us to avoid multiple instantiations for each request (saves memory).
+         */
+        @SuppressWarnings("unchecked") // Safe because of erasure.
+        static <RT, ET> OperatorMapResponseToBodyOrError<RT, ET> instance() {
+            return (OperatorMapResponseToBodyOrError<RT, ET>) INSTANCE;
+        }
+
+        @Override
+        public Subscriber<? super Response<RT, ET>> call(final Subscriber<? super RT> child) {
+            return new Subscriber<Response<RT, ET>>(child) {
+                @Override
+                public void onNext(Response<RT, ET> response) {
+                    if (response.isSuccessful()) {
+                        child.onNext(response.body());
+                    } else {
+                        child.onError(new HttpException(response));
+                    }
+                }
+
+                @Override
+                public void onCompleted() {
+                    child.onCompleted();
+                }
+
+                @Override
+                public void onError(Throwable th) {
+                    child.onError(th);
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
This divides the public api of CallSpec and it's implementation into two
different classes. This will provided better testability support as well
as better overview of the libraries public api.

As a side note, some documentation was added for the public api of CallSpec.
