### PR TITLE
Allow generic error body parsing.

### DIFF
--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -290,6 +290,10 @@ public interface CallSpec<RT, ET> extends Cloneable {
 
         //This is needed for XING internal APIs that return the error message in a custom format.
         public Builder<RT, ET> errorAs(Class<ET> type) {
+            return errorAs((Type) type);
+        }
+
+        public Builder<RT, ET> errorAs(Type type) {
             errorType = checkNotNull(type, "type == null");
             return this;
         }


### PR DESCRIPTION
This allows to specify a composite type for a error response. 
