### PR TITLE
Add support for three letter ISO 8601 dates

### DIFF
--- a/api-client/src/main/java/com/xing/api/internal/json/SafeCalendarJsonAdapter.java
+++ b/api-client/src/main/java/com/xing/api/internal/json/SafeCalendarJsonAdapter.java
@@ -50,10 +50,13 @@ public final class SafeCalendarJsonAdapter<T extends Calendar> extends JsonAdapt
     private static final String REG_EX_YEAR_MONTH_DAY = "^(19|20)\\d{2}-\\d{2}-\\d{2}$";
     private static final String REG_EX_ISO_DATE_Z = "^(19|20)\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$";
     private static final String REG_EX_ISO_DATE_TIME = "^(19|20)\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+]\\d{4}$";
+    private static final String REG_EX_THREE_LETTER_ISO8601_DATE_FORMAT =
+          "^(19|20)\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+]\\d{2}:\\d{2}$";
     private static final String REG_EX_ISO_DATE_WEIRD = "^(19|20)\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z$";
 
     private static final String ISO_DATE_FORMAT_Z = "yyyy-MM-dd'T'HH:mm:ss'Z'";
     private static final String ISO_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+    private static final String THREE_LETTER_ISO8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
     private static final String ISO_DATE_FORMAT_WEIRD = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     private static final String YEAR_DATE_FORMAT = "yyyy";
     private static final String YEAR_MONTH_DATE_FORMAT = "yyyy-MM";
@@ -68,6 +71,8 @@ public final class SafeCalendarJsonAdapter<T extends Calendar> extends JsonAdapt
         DATE_FORMAT_MAP.put(REG_EX_YEAR_MONTH_DAY, new SimpleDateFormat(YEAR_MONTH_DAY_DATE_FORMAT, Locale.ENGLISH));
         DATE_FORMAT_MAP.put(REG_EX_ISO_DATE_Z, new SimpleDateFormat(ISO_DATE_FORMAT_Z, Locale.ENGLISH));
         DATE_FORMAT_MAP.put(REG_EX_ISO_DATE_TIME, new SimpleDateFormat(ISO_DATE_FORMAT, Locale.ENGLISH));
+        DATE_FORMAT_MAP.put(REG_EX_THREE_LETTER_ISO8601_DATE_FORMAT,
+              new SimpleDateFormat(THREE_LETTER_ISO8601_DATE_FORMAT, Locale.ENGLISH));
         DATE_FORMAT_MAP.put(REG_EX_ISO_DATE_WEIRD, new SimpleDateFormat(ISO_DATE_FORMAT_WEIRD, Locale.ENGLISH));
     }
 

--- a/api-client/src/test/java/com/xing/api/internal/json/SafeCalendarJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/SafeCalendarJsonAdapterTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.mock;
  * <li>"yyyy-MM-dd"</li>
  * <li>"yyyy-MM-dd'T'HH:mm.ssZ"</li>
  * <li>"yyyy-MM-dd'T'HH:mm.ss.SSSZ"</li>
+ * <li>"yyyy-MM-dd'T'HH:mm:ssXXX"</li>
  * <p>
  *
  * @author serj.lotutovici
@@ -215,6 +216,35 @@ public class SafeCalendarJsonAdapterTest {
             assertThat(fromJson.get(Calendar.HOUR_OF_DAY)).isEqualTo(21);
             assertThat(fromJson.get(Calendar.MINUTE)).isEqualTo(0);
             assertThat(fromJson.get(Calendar.SECOND)).isEqualTo(23);
+        } finally {
+            // Return pre test time zone.
+            TimeZone.setDefault(preTestTimeZone);
+        }
+    }
+
+    @Test
+    public void threeLetterIso8601withTimeZone() throws Exception {
+        // Need to reset time zone.
+        TimeZone preTestTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+        try {
+            Calendar fromJson = calendarAdapter().fromJson("\"2003-04-21T16:42:11+02:00\"");
+            assertNotNull(fromJson);
+
+            assertTrue(fromJson.isSet(Calendar.SECOND));
+            assertTrue(fromJson.isSet(Calendar.MINUTE));
+            assertTrue(fromJson.isSet(Calendar.HOUR));
+            assertTrue(fromJson.isSet(Calendar.DAY_OF_MONTH));
+            assertTrue(fromJson.isSet(Calendar.MONTH));
+            assertTrue(fromJson.isSet(Calendar.YEAR));
+
+            assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(2003);
+            assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.APRIL);
+            assertThat(fromJson.get(Calendar.DAY_OF_MONTH)).isEqualTo(21);
+            assertThat(fromJson.get(Calendar.HOUR_OF_DAY)).isEqualTo(14);
+            assertThat(fromJson.get(Calendar.MINUTE)).isEqualTo(42);
+            assertThat(fromJson.get(Calendar.SECOND)).isEqualTo(11);
         } finally {
             // Return pre test time zone.
             TimeZone.setDefault(preTestTimeZone);


### PR DESCRIPTION
Add support for [three letter ISO 8601](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html#iso8601timezone) dates, e.g. "2001-07-04T12:08:56.+2:00"
