### PR TITLE
Parse error response with empty body.

### DIFF
--- a/api-client/src/main/java/com/xing/api/Response.java
+++ b/api-client/src/main/java/com/xing/api/Response.java
@@ -20,9 +20,7 @@ import okhttp3.Headers;
 
 import static com.xing.api.Utils.checkNotNull;
 
-/**
- * TODO docs.
- */
+/** TODO docs. */
 public final class Response<RT, ET> {
     /** Returns a successful {@link Response} with a {@code null} error body. */
     static <RT, ET> Response<RT, ET> success(RT body, okhttp3.Response rawResponse) {
@@ -40,9 +38,9 @@ public final class Response<RT, ET> {
     }
 
     private final okhttp3.Response rawResponse;
+    private final ContentRange range;
     private final RT body;
     private final ET error;
-    private final ContentRange range;
 
     private Response(okhttp3.Response rawResponse, ContentRange range, RT body, ET error) {
         this.rawResponse = checkNotNull(rawResponse, "rawResponse == null");
@@ -75,12 +73,18 @@ public final class Response<RT, ET> {
         return rawResponse.isSuccessful();
     }
 
-    /** The de-serialized response body of a {@linkplain #isSuccessful() successful} response. */
+    /**
+     * The de-serialized response body of a {@linkplain #isSuccessful() successful} response
+     * or null if the response was unsuccessful.
+     */
     public RT body() {
         return body;
     }
 
-    /** The parsed error response of an {@linkplain #isSuccessful() unsuccessful} response. */
+    /**
+     * The parsed error response of an {@linkplain #isSuccessful() unsuccessful} response
+     * or null if the error contains no body.
+     */
     public ET error() {
         return error;
     }

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -530,6 +530,19 @@ public class CallSpecTest {
     }
 
     @Test
+    public void specHandlesErrorResponseWithoutBody() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(300));
+
+        CallSpec<Object, TestMsg> spec = this.<Object, TestMsg>builder(HttpMethod.GET, "/", false)
+              .responseAs(Object.class)
+              .errorAs(TestMsg.class)
+              .build();
+
+        Response<Object, TestMsg> response = spec.execute();
+        assertEnmptyErrorResponse(response, 300);
+    }
+
+    @Test
     public void specThrowsIfUnauthorized() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(401));
 
@@ -968,6 +981,13 @@ public class CallSpecTest {
         assertNotNull(body);
         assertThat(body.msg).isEqualTo(expected.msg);
         assertThat(body.code).isEqualTo(expected.code);
+    }
+
+    private static void assertEnmptyErrorResponse(Response<Object, TestMsg> response, int code) {
+        assertThat(response.isSuccessful()).isFalse();
+        assertThat(response.code()).isEqualTo(code);
+        assertThat(response.body()).isNull();
+        assertThat(response.error()).isNull();
     }
 
     private static void assertRequestHasBody(Request request, TestMsg expected, int contentLength) throws IOException {


### PR DESCRIPTION
_Whenever we get a response with an error code it could happen that the body is empty (for example for 404 - NOT_FOUND). With this modification the result will still be a `Response` with a null error but maintaining the error code inside so the clients can identify it._

_Also changed some attributes to package-local to avoid synthetic accessor methods._

Dependencies:
- [x] Unit Tests
