### PR TITLE
Add posibility to set a OkHttp cache.

### DIFF
--- a/api-client/src/main/java/com/xing/api/XingApi.java
+++ b/api-client/src/main/java/com/xing/api/XingApi.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
+import okhttp3.Cache;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -201,6 +202,11 @@ public final class XingApi {
 
         public Builder apiEndpoint(HttpUrl baseUrl) {
             apiEndpoint = checkNotNull(baseUrl, "apiEndpoint == null");
+            return this;
+        }
+
+        public Builder cache(Cache cache) {
+            clientBuilder.cache(checkNotNull(cache, "cache == null"));
             return this;
         }
 

--- a/api-client/src/test/java/com/xing/api/XingApiTest.java
+++ b/api-client/src/test/java/com/xing/api/XingApiTest.java
@@ -17,15 +17,18 @@ package com.xing.api;
 
 import com.squareup.moshi.Moshi;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import okhttp3.Cache;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
@@ -168,6 +171,13 @@ public class XingApiTest {
         }
 
         try {
+            builder.cache(null);
+            Assert.fail();
+        } catch (NullPointerException expected) {
+            assertThat(expected.getMessage()).isEqualTo("cache == null");
+        }
+
+        try {
             builder.callbackExecutor(null);
             fail("Builder should throw on null values.");
         } catch (NullPointerException expected) {
@@ -234,6 +244,17 @@ public class XingApiTest {
         assertThat(client.interceptors().get(0).toString()).isEqualTo("one");
         assertThat(client.interceptors().get(1).toString()).isEqualTo("two");
         assertThat(client.interceptors().get(2)).isInstanceOf(OAuth1SigningInterceptor.class);
+    }
+
+    @Test
+    public void cacheIsPorpagated() throws Exception {
+        Cache cache = new Cache(new File("test"), 42);
+        XingApi tested = new XingApi.Builder()
+              .cache(cache)
+              .loggedOut()
+              .build();
+
+        assertThat(tested.client().cache()).isSameAs(cache);
     }
 
     @Test


### PR DESCRIPTION
This is a fast solution... But I think we need a better way of doing that, by not complementing all okhttp builder methods.
