### PR TITLE
-Fixed zulu time bug: if not set DateFormat uses default timezone in …

### DIFF
--- a/api-client/src/test/java/com/xing/api/resources/ContactsResourceTest.java
+++ b/api-client/src/test/java/com/xing/api/resources/ContactsResourceTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.util.Calendar;
 import java.util.List;
+import java.util.TimeZone;
 
 import okhttp3.mockwebserver.MockResponse;
 
@@ -198,11 +199,13 @@ public class ContactsResourceTest extends ResourceTestCase<ContactsResource> {
 
         Response<List<ContactRequest>, HttpError> response = resource.getIncomingContactRequests().execute();
         // If no exception was thrown then the spec is build correctly.
+        SafeCalendar safeCalendar = new SafeCalendar(2010, Calendar.NOVEMBER, 17, 10, 56, 16);
+        safeCalendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         assertThat(response.body()).containsExactly(
               new ContactRequest()
                     .message("Sehr geehrter Herr Irgendwas, ich würde Sie gern zu meinen Kontakten hinzufügen")
                     .senderId("6055623_5cf823")
-                    .receivedAt(new SafeCalendar(2010, Calendar.NOVEMBER, 17, 10, 56, 16))
+                    .receivedAt(safeCalendar)
                     .sender(new XingUser().id("6055623_5cf823").displayName("John Doe")));
     }
 

--- a/api-client/src/test/java/com/xing/api/resources/UserProfilesResourceTest.java
+++ b/api-client/src/test/java/com/xing/api/resources/UserProfilesResourceTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.TimeZone;
 
 import okhttp3.mockwebserver.MockResponse;
 
@@ -181,12 +182,14 @@ public final class UserProfilesResourceTest extends ResourceTestCase<UserProfile
 
         Response<ProfileMessage, HttpError> response1 = resource.getUserProfileMessage("test").execute();
         // If no exception was thrown then the spec is build correctly.
-        assertThat(response1.body().updatedAt()).isEqualTo(new SafeCalendar(2011, 6, 18, 11, 40, 19));
+        SafeCalendar safeCalendar = new SafeCalendar(2011, 6, 18, 11, 40, 19);
+        safeCalendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        assertThat(response1.body().updatedAt()).isEqualTo(safeCalendar);
         assertThat(response1.body().message()).isEqualTo("My new profile message.");
 
         Response<ProfileMessage, HttpError> response2 = resource.getOwnProfileMessage().execute();
         // If no exception was thrown then the spec is build correctly.
-        assertThat(response2.body().updatedAt()).isEqualTo(new SafeCalendar(2011, 6, 18, 11, 40, 19));
+        assertThat(response2.body().updatedAt()).isEqualTo(safeCalendar);
         assertThat(response2.body().message()).isEqualTo("My new profile message.");
     }
 


### PR DESCRIPTION
-Fixed zulu time bug: if not set DateFormat uses default timezone in order to parse string which lead to incorrect timestamp for zulu time (offset of zulu 0)
-Improved performance of the parsing by extracting regexp compilation to static variables. They will be compiled once as soon as classloader will load JsonAdapter (used to be every time you find SafeCalendar field for every single format)
-Minor refactoring

Dependencies:__
- [x] @serj-lotutovici
- [x] @Shyish
- [x] @dhartwich1991
- [x] Unit Tests
