### PR TITLE
Fix (NotSo)SafeCalendar time zone offset serialization.

### DIFF
--- a/api-client/src/main/java/com/xing/api/internal/json/SafeCalendarJsonAdapter.java
+++ b/api-client/src/main/java/com/xing/api/internal/json/SafeCalendarJsonAdapter.java
@@ -114,6 +114,7 @@ public final class SafeCalendarJsonAdapter<T extends Calendar> extends JsonAdapt
      * @param calendar The calendar to clear
      * @param regEx The reg ex
      */
+    @SuppressWarnings("fallthrough")
     private static void clearCalendarByRegEx(Calendar calendar, String regEx) {
         switch (regEx) {
             case YEAR_DATE_FORMAT: {
@@ -204,7 +205,19 @@ public final class SafeCalendarJsonAdapter<T extends Calendar> extends JsonAdapt
                         output.append(TWO_DIGITS_FORMATTER.format(calendar.get(Calendar.MINUTE)));
                         output.append(':');
                         output.append(TWO_DIGITS_FORMATTER.format(calendar.get(Calendar.SECOND)));
-                        output.append('Z');
+                        if (ZULU_TIME_ZONE.equals(calendar.getTimeZone())) {
+                            output.append('Z');
+                        } else {
+                            TimeZone timeZone = calendar.getTimeZone();
+                            // This will return the initial time milliseconds + offset milliseconds
+                            long millisWithOffset = timeZone.getOffset(calendar.getTimeInMillis());
+                            String offset = String.format("%02d:%02d",
+                                  // Get the amount of hours form the offset
+                                  Math.abs(millisWithOffset / 3600000),
+                                  // Get the amount of minutes form the offset
+                                  Math.abs((millisWithOffset / 60000) % 60));
+                            output.append((millisWithOffset >= 0 ? "+" : "-")).append(offset);
+                        }
                     }
                 }
             }

--- a/api-client/src/test/java/com/xing/api/internal/json/TimeZoneRule.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/TimeZoneRule.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api.internal.json;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.util.TimeZone;
+
+final class TimeZoneRule extends TestWatcher {
+    private final TimeZone originalTimeZone = TimeZone.getDefault();
+    private final TimeZone timeZone;
+
+    public TimeZoneRule(TimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    @Override
+    protected void starting(Description description) {
+        TimeZone.setDefault(timeZone);
+    }
+
+    @Override
+    protected void finished(Description description) {
+        TimeZone.setDefault(originalTimeZone);
+    }
+}


### PR DESCRIPTION
Well, it seams that we missed the serialization support for time zone offsets. This fixes it.
Special thanks to @danielgoncharov

Dependencies:
- [x] @dhartwich1991 
