### PR TITLE
Deprecate XingUser's empty constructor.

### DIFF
--- a/api-client/src/main/java/com/xing/api/data/profile/XingUser.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/XingUser.java
@@ -41,7 +41,7 @@ public class XingUser implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Json(name = "id")
-    private String id;
+    private /* TODO: make final */ String id;
     @Json(name = "academic_title")
     private String academicTitle;
     @Json(name = "first_name")
@@ -102,6 +102,21 @@ public class XingUser implements Serializable {
     private PhotoUrls photoUrls;
     @Json(name = "legal_information")
     private LegalInformation legalInformation;
+
+    /**
+     * Create an instance of {@linkplain XingUser}.
+     *
+     * @deprecated A user can not exist without an {@linkplain #id()}. Use {@linkplain XingUser#XingUser(String)}. The
+     * user id can be returned {@code null} by XWS only if the user is blacklisted, see {@linkplain #isBlacklisted()}.
+     */
+    @Deprecated
+    public XingUser() {
+    }
+
+    /** Create an {@linkplain XingUser} instance with the respective user id. */
+    public XingUser(String id) {
+        this.id = id;
+    }
 
     @SuppressWarnings("SimplifiableIfStatement")
     @Override
@@ -244,6 +259,8 @@ public class XingUser implements Serializable {
         return id;
     }
 
+    /** @deprecated See {@linkplain XingUser#XingUser()}. */
+    @Deprecated
     public XingUser id(String id) {
         this.id = id;
         return this;

--- a/api-client/src/test/java/com/xing/api/data/profile/XingUserTest.java
+++ b/api-client/src/test/java/com/xing/api/data/profile/XingUserTest.java
@@ -17,7 +17,7 @@ public class XingUserTest {
 
     @Before
     public void setUp() throws Exception {
-        user = new XingUser()
+        user = new XingUser(null)
               .addPremiumService(PremiumService.PRIVATE_MESSAGES)
               .professionalExperience(
                     new ProfessionalExperience()
@@ -66,16 +66,16 @@ public class XingUserTest {
     @Test
     public void testIsPremium() throws Exception {
         assertThat(user.isPremium()).isEqualTo(true);
-        XingUser basicUser = new XingUser().premiumServices(Collections.<PremiumService>emptyList());
+        XingUser basicUser = new XingUser(null).premiumServices(Collections.<PremiumService>emptyList());
         assertThat(basicUser.isPremium()).isEqualTo(false);
-        XingUser nullUser = new XingUser().premiumServices(null);
+        XingUser nullUser = new XingUser(null).premiumServices(null);
         assertThat(nullUser.isPremium()).isEqualTo(false);
     }
 
     @Test
     public void testIsBlackListed() throws Exception {
-        assertThat(new XingUser().id(null).isBlacklisted()).isTrue();
-        assertThat(new XingUser().id("").isBlacklisted()).isTrue();
-        assertThat(new XingUser().id("some_id").isBlacklisted()).isFalse();
+        assertThat(new XingUser(null).isBlacklisted()).isTrue();
+        assertThat(new XingUser("").isBlacklisted()).isTrue();
+        assertThat(new XingUser("some_id").isBlacklisted()).isFalse();
     }
 }

--- a/api-client/src/test/java/com/xing/api/resources/ContactsResourceTest.java
+++ b/api-client/src/test/java/com/xing/api/resources/ContactsResourceTest.java
@@ -206,7 +206,7 @@ public class ContactsResourceTest extends ResourceTestCase<ContactsResource> {
                     .message("Sehr geehrter Herr Irgendwas, ich würde Sie gern zu meinen Kontakten hinzufügen")
                     .senderId("6055623_5cf823")
                     .receivedAt(safeCalendar)
-                    .sender(new XingUser().id("6055623_5cf823").displayName("John Doe")));
+                    .sender(new XingUser("6055623_5cf823").displayName("John Doe")));
     }
 
     @Test

--- a/api-client/src/test/java/com/xing/api/resources/RecommendationsResourceTest.java
+++ b/api-client/src/test/java/com/xing/api/resources/RecommendationsResourceTest.java
@@ -65,12 +65,10 @@ public final class RecommendationsResourceTest extends ResourceTestCase<Recommen
         // If no exception was thrown then the spec is build correctly.
         assertThat(response.isSuccessful()).isTrue();
         assertThat(response.body()).containsExactly(
-              new XingUser()
-                    .id("123123_abcdef")
+              new XingUser("123123_abcdef")
                     .displayName("Marianne Musterfrau")
                     .gender(Gender.FEMALE),
-              new XingUser()
-                    .id("111111_cccccc")
+              new XingUser("111111_cccccc")
                     .displayName("Max Musterdude")
                     .gender(Gender.MALE)
         );


### PR DESCRIPTION
The api client uses the models as a representation of the response. If the `XingUser` model is created manually by the user of the library, (s)he should be aware of the logic tied to the id field.

cc @dhartwich1991 
