### PR TITLE
Make LeagalInfromation serializable

### DIFF
--- a/api-client/src/main/java/com/xing/api/data/profile/LegalInformation.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/LegalInformation.java
@@ -3,6 +3,8 @@ package com.xing.api.data.profile;
 import com.squareup.moshi.Json;
 import com.xing.api.resources.UserProfilesResource;
 
+import java.io.Serializable;
+
 /**
  * Part of the {@link XingUser} that contains the user's set legal information as a preview.
  * <p>
@@ -10,7 +12,8 @@ import com.xing.api.resources.UserProfilesResource;
  * {@link UserProfilesResource#getUserLegalInformation(String)}
  */
 @SuppressWarnings("unused")
-public class LegalInformation {
+public class LegalInformation implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @Json(name = "preview_content")
     private String previewContent;
@@ -27,6 +30,15 @@ public class LegalInformation {
     @Override
     public int hashCode() {
         return previewContent != null ? previewContent.hashCode() : 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof LegalInformation)) return false;
+
+        LegalInformation that = (LegalInformation) obj;
+        return previewContent != null ? previewContent.equals(that.previewContent) : that.previewContent == null;
     }
 
     @Override

--- a/api-client/src/test/java/com/xing/api/JsonSerializationTest.java
+++ b/api-client/src/test/java/com/xing/api/JsonSerializationTest.java
@@ -92,6 +92,9 @@ public class JsonSerializationTest {
         assertThat(user.languages()).containsExactly(
               MapEntry.entry(Language.DE, LanguageSkill.NATIVE), MapEntry.entry(Language.EN, LanguageSkill.FLUENT),
               MapEntry.entry(Language.FR, null), MapEntry.entry(Language.ZH, LanguageSkill.BASIC));
+        assertThat(user.legalInformation().previewContent())
+              .isEqualTo("Max Mustermann\nMuster AG\nMusterstraße 123\n22992 Musterdorf");
+
 
         // Addresses.
         assertPrivateAddress(user);

--- a/api-client/src/test/resources/user.json
+++ b/api-client/src/test/resources/user.json
@@ -253,5 +253,8 @@
     "size_256x256": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.256x256.jpg",
     "size_1024x1024": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.1024x1024.jpg",
     "size_original": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.original.jpg"
+  },
+  "legal_information": {
+    "preview_content": "Max Mustermann\nMuster AG\nMusterstraße 123\n22992 Musterdorf"
   }
 }


### PR DESCRIPTION
Also implement `equals` to not break comparison logic.
cc @jacopocafarelli 
