### PR TITLE
Updated CsvCollectionJsonAdapter to process comma separation w/o whitespace

### DIFF
--- a/api-client/src/main/java/com/xing/api/internal/json/CsvCollectionJsonAdapter.java
+++ b/api-client/src/main/java/com/xing/api/internal/json/CsvCollectionJsonAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (С) 2015 XING AG (http://xing.com/)
+ * Copyright (c) 2016 XING AG (http://xing.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,14 @@ import java.util.regex.Pattern;
 
 /** Adapter that parses comma separated value strings into a collection. */
 public abstract class CsvCollectionJsonAdapter<C extends Collection<String>> extends JsonAdapter<C> {
-    private static final String COMMA_DELIMITER = ", ";
+    private static final String COMMA_DELIMITER = ",";
     private static final Pattern COMMA_SEPARATOR = Pattern.compile(COMMA_DELIMITER);
 
+    private static final String COMMA_SPACE_DELIMITER = ", ";
+    private static final Pattern COMMA_SPACE_SEPARATOR = Pattern.compile(COMMA_SPACE_DELIMITER);
+
     /** Comma separated values adapter factory. */
-    public static final JsonAdapter.Factory FACTORY = new Factory() {
+    public static final Factory FACTORY = new Factory() {
         @Override
         public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
             if (annotations.isEmpty() || annotations.size() != 1
@@ -94,7 +97,8 @@ public abstract class CsvCollectionJsonAdapter<C extends Collection<String>> ext
     public C fromJson(JsonReader reader) throws IOException {
         C result = newCollection();
         String csString = reader.nextString();
-        String[] strings = COMMA_SEPARATOR.split(csString);
+        String removeSpaces = COMMA_SPACE_SEPARATOR.matcher(csString).replaceAll(COMMA_DELIMITER);
+        String[] strings = COMMA_SEPARATOR.split(removeSpaces);
         for (int index = 0, size = strings.length; index < size; index++) {
             result.add(strings[index]);
         }

--- a/api-client/src/main/java/com/xing/api/internal/json/CsvCollectionJsonAdapter.java
+++ b/api-client/src/main/java/com/xing/api/internal/json/CsvCollectionJsonAdapter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.xing.api.internal.json;
 
 import com.squareup.moshi.JsonAdapter;
@@ -40,7 +41,7 @@ public abstract class CsvCollectionJsonAdapter<C extends Collection<String>> ext
     private static final Pattern COMMA_SPACE_SEPARATOR = Pattern.compile(COMMA_SPACE_DELIMITER);
 
     /** Comma separated values adapter factory. */
-    public static final Factory FACTORY = new Factory() {
+    public static final JsonAdapter.Factory FACTORY = new Factory() {
         @Override
         public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
             if (annotations.isEmpty() || annotations.size() != 1
@@ -113,7 +114,7 @@ public abstract class CsvCollectionJsonAdapter<C extends Collection<String>> ext
             if (firstTime) {
                 firstTime = false;
             } else {
-                sb.append(COMMA_DELIMITER);
+                sb.append(COMMA_SPACE_DELIMITER);
             }
             sb.append(token);
         }

--- a/api-client/src/test/java/com/xing/api/internal/json/CsvCollectionJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/CsvCollectionJsonAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (С) 2015 XING AG (http://xing.com/)
+ * Copyright (c) 2016 XING AG (http://xing.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,6 +109,9 @@ public class CsvCollectionJsonAdapterTest {
 
         C fromJson = fromJson(collectionClass, "\"test1, test2, test3\"");
         assertThat(fromJson).containsExactly("test1", "test2", "test3");
+
+        C fromJsonNoSpace = fromJson(collectionClass, "\"test1,test2,test3\"");
+        assertThat(fromJsonNoSpace).containsExactly("test1", "test2", "test3");
     }
 
     private <C extends Collection<String>> String toJson(Type collectionType, C collection) throws IOException {


### PR DESCRIPTION
Updated CsvCollectionJsonAdapter to process also strings separated by just a comma w/o a whitespace ._

**Issue:** <Github Issue>

Dependencies:__
- [x] Unit Tests
