### PR TITLE
Introduce OAuthResponse to api-client-android-oauth

### DIFF
--- a/api-client-android-oauth/build.gradle
+++ b/api-client-android-oauth/build.gradle
@@ -52,6 +52,10 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
+
+    testOptions { 
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -60,12 +64,14 @@ dependencies {
     }
 
     provided libraries.supportAnnotations
+    provided libraries.supportV4
     compile libraries.singpost
 
     testCompile libraries.junit
     testCompile libraries.assertj
     testCompile libraries.mockito
     testCompile libraries.robolectric
+    testCompile libraries.robolectircSupport
 }
 /*
  *  ============== Artifacts publishing section ==============

--- a/api-client-android-oauth/src/main/java/com/xing/api/oauth/OAuthResponse.java
+++ b/api-client-android-oauth/src/main/java/com/xing/api/oauth/OAuthResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 XING AG (http://xing.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.xing.api.oauth;
+
+/**
+ * Represents the OAuth response. <strong>This</strong> bundles the users {@code token} and {@code tokenSecret} that
+ * should be stored by the consumer.
+ */
+public final class OAuthResponse {
+    /** Builds a successful {@linkplain OAuthResponse}. */
+    static OAuthResponse success(String token, String tokenSecret) {
+        return new OAuthResponse(token, tokenSecret, null);
+    }
+
+    /** Builds an error {@linkplain OAuthResponse}. */
+    static OAuthResponse error(String errorReason) {
+        return new OAuthResponse(null, null, errorReason);
+    }
+
+    private final String token;
+    private final String tokenSecret;
+
+    // TODO: (2.1.0) allow consumers to read the error reason.
+    private final String errorReason;
+
+    OAuthResponse(String token, String tokenSecret, String errorReason) {
+        this.token = token;
+        this.tokenSecret = tokenSecret;
+        this.errorReason = errorReason;
+    }
+
+    public String token() {
+        return token;
+    }
+
+    public String tokenSecret() {
+        return tokenSecret;
+    }
+
+    /** Returns {@code true} if the authentication was successful. */
+    public boolean isSuccessful() {
+        return errorReason == null;
+    }
+}

--- a/api-client-android-oauth/src/main/java/com/xing/api/oauth/XingOAuthCallback.java
+++ b/api-client-android-oauth/src/main/java/com/xing/api/oauth/XingOAuthCallback.java
@@ -15,7 +15,12 @@
  */
 package com.xing.api.oauth;
 
-/** Callback used to react on the authentication process. */
+/**
+ * Callback used to react on the authentication process.
+ *
+ * @deprecated Use {@linkplain OAuthResponse} instead.
+ */
+@Deprecated
 public interface XingOAuthCallback {
     void onSuccess(String token, String tokenSecret);
 

--- a/api-client-android-sample/src/main/java/com/xing/api/sample/ui/LoginActivity.java
+++ b/api-client-android-sample/src/main/java/com/xing/api/sample/ui/LoginActivity.java
@@ -22,13 +22,13 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
-import com.xing.api.oauth.XingOAuthCallback;
+import com.xing.api.oauth.OAuthResponse;
 import com.xing.api.oauth.XingOAuth;
 import com.xing.api.sample.BuildConfig;
 import com.xing.api.sample.Prefs;
 import com.xing.api.sample.R;
 
-public class LoginActivity extends BaseActivity implements View.OnClickListener, XingOAuthCallback {
+public class LoginActivity extends BaseActivity implements View.OnClickListener {
     private XingOAuth xingOAuth;
 
     @Override
@@ -48,7 +48,6 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
             xingOAuth = new XingOAuth.Builder()
                   .consumerKey(BuildConfig.OAUTH_CONSUMER_KEY)
                   .consumerSecret(BuildConfig.OAUTH_CONSUMER_SECRET)
-                  .oauthCallback(this)
                   .callbackUrlDebug()
                   .build();
         }
@@ -65,23 +64,20 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        xingOAuth.onActivityResult(requestCode, resultCode, data);
-    }
+        OAuthResponse response = xingOAuth.onActivityResult(requestCode, resultCode, data);
+        if (response != null) {
+            if (response.isSuccessful()) {
+                showToast("ok");
 
-    @Override
-    public void onSuccess(String token, String tokenSecret) {
-        showToast("ok");
+                Prefs.getInstance(this).setOauthToken(response.token());
+                Prefs.getInstance(this).setOauthSecret(response.tokenSecret());
 
-        Prefs.getInstance(this).setOauthToken(token);
-        Prefs.getInstance(this).setOauthSecret(tokenSecret);
-
-        startActivity(new Intent(this, ProfileActivity.class).setFlags(
-              Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP));
-        finish();
-    }
-
-    @Override
-    public void onError() {
-        showToast("error");
+                startActivity(new Intent(this, ProfileActivity.class).setFlags(
+                      Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP));
+                finish();
+            } else {
+                showToast("error");
+            }
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,8 @@ allprojects {
               junit                   : 'junit:junit:4.12',
               assertj                 : 'org.assertj:assertj-core:1.7.0',
               mockito                 : 'org.mockito:mockito-all:1.10.19',
-              robolectric             : 'org.robolectric:robolectric:3.1.1',
+              robolectric             : 'org.robolectric:robolectric:3.1.2',
+              robolectircSupport      : 'org.robolectric:shadows-support-v4:3.1.2',
               mockWebServer           : 'com.squareup.okhttp3:mockwebserver:3.2.0',
               commonsIo               : 'commons-io:commons-io:2.4',
               apacheCommons3          : 'org.apache.commons:commons-lang3:3.4'


### PR DESCRIPTION
- Adds an OAuthResponse class similar to the Resposne class.
- Deprecates XingOAuthCallback
- Increases XingOAuth coverage.

Closes #142 

cc @ricamgar 
