### PR TITLE
API call updateLegalInfo send content as body instead of query param.…

### DIFF
--- a/api-client/src/main/java/com/xing/api/data/profile/LegalInformation.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/LegalInformation.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
  */
 @SuppressWarnings("unused")
 public class LegalInformation implements Serializable {
-    // TODO: 05/08/16 FIX ME. Better name would be LegalInformationPreview
+    // TODO: FIX ME. Better name would be LegalInformationPreview
     private static final long serialVersionUID = 1L;
 
     @Json(name = "preview_content")

--- a/api-client/src/main/java/com/xing/api/data/profile/LegalInformation.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/LegalInformation.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
  */
 @SuppressWarnings("unused")
 public class LegalInformation implements Serializable {
+    // TODO: 05/08/16 FIX ME. Better name would be LegalInformationPreview
     private static final long serialVersionUID = 1L;
 
     @Json(name = "preview_content")

--- a/api-client/src/main/java/com/xing/api/data/profile/LegalInformationComplete.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/LegalInformationComplete.java
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json;
 
 import java.io.Serializable;
 
-/** Represents full legal information */
+/** Represents full legal information. */
 public class LegalInformationComplete implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -22,10 +22,9 @@ public class LegalInformationComplete implements Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof LegalInformationComplete)) return false;
 
         LegalInformationComplete that = (LegalInformationComplete) o;
-
         return content != null ? content.equals(that.content) : that.content == null;
     }
 
@@ -36,8 +35,8 @@ public class LegalInformationComplete implements Serializable {
 
     @Override
     public String toString() {
-        return "LegalInformationComplete{" +
-              "content='" + content + '\'' +
-              '}';
+        return "LegalInformationComplete{"
+              + "content='" + content + '\''
+              + '}';
     }
 }

--- a/api-client/src/main/java/com/xing/api/data/profile/LegalInformationComplete.java
+++ b/api-client/src/main/java/com/xing/api/data/profile/LegalInformationComplete.java
@@ -1,0 +1,43 @@
+package com.xing.api.data.profile;
+
+import com.squareup.moshi.Json;
+
+import java.io.Serializable;
+
+/** Represents full legal information */
+public class LegalInformationComplete implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Json(name = "content")
+    private String content;
+
+    public LegalInformationComplete(String content) {
+        this.content = content;
+    }
+
+    public String content() {
+        return content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LegalInformationComplete that = (LegalInformationComplete) o;
+
+        return content != null ? content.equals(that.content) : that.content == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return content != null ? content.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "LegalInformationComplete{" +
+              "content='" + content + '\'' +
+              '}';
+    }
+}

--- a/api-client/src/main/java/com/xing/api/resources/ProfileEditingResource.java
+++ b/api-client/src/main/java/com/xing/api/resources/ProfileEditingResource.java
@@ -27,6 +27,7 @@ import com.xing.api.data.profile.Company;
 import com.xing.api.data.profile.FormOfEmployment;
 import com.xing.api.data.profile.Language;
 import com.xing.api.data.profile.LanguageSkill;
+import com.xing.api.data.profile.LegalInformationComplete;
 import com.xing.api.data.profile.MessagingAccount;
 import com.xing.api.data.profile.School;
 import com.xing.api.data.profile.WebProfile;
@@ -873,7 +874,7 @@ public class ProfileEditingResource extends Resource {
     public CallSpec<Void, HttpError> updateLegalInfo(String legalInfo) {
         return Resource.<Void, HttpError>newPutSpec(api, "/v1/users/me/legal_information", false)
               .responseAs(Void.class)
-              .queryParam("content", legalInfo)
+              .body(LegalInformationComplete.class, new LegalInformationComplete(legalInfo))
               .build();
     }
 


### PR DESCRIPTION
Send legal information update as `body` instead of `query param`. This allows to accept characters as asterix `*`
