### PR TITLE
Escape String form fields.

### DIFF
--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -35,9 +35,9 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okio.Buffer;
+import rx.Completable;
 import rx.Observable;
 import rx.Single;
-import rx.Completable;
 
 import static com.xing.api.UrlEscapeUtils.escape;
 import static com.xing.api.Utils.assertionError;
@@ -138,6 +138,14 @@ public interface CallSpec<RT, ET> extends Cloneable {
      * creation.
      */
     CallSpec<RT, ET> formField(String name, String value);
+
+    /**
+     * Adds a form field to the underlying request's form body.
+     *
+     * <p>This will throw an {@linkplain NullPointerException} if the form body support was not specified during spec
+     * creation.
+     */
+    CallSpec<RT, ET> formField(String name, Object value);
 
     /**
      * Adds a form field as a csv list to the underlying request's form body.
@@ -272,6 +280,12 @@ public interface CallSpec<RT, ET> extends Cloneable {
             return queryParam(name, toCsv(values, false));
         }
 
+        public Builder<RT, ET> formField(String name, String value) {
+            stateNotNull(formBodyBuilder, "form fields are not accepted by this request.");
+            formBodyBuilder.add(name, escape(value));
+            return this;
+        }
+
         public Builder<RT, ET> formField(String name, Object value) {
             stateNotNull(formBodyBuilder, "form fields are not accepted by this request.");
             formBodyBuilder.add(name, String.valueOf(value));
@@ -279,11 +293,15 @@ public interface CallSpec<RT, ET> extends Cloneable {
         }
 
         public Builder<RT, ET> formField(String name, String... values) {
-            return formField(name, toCsv(values, true));
+            stateNotNull(formBodyBuilder, "form fields are not accepted by this request.");
+            formBodyBuilder.add(name, toCsv(values, true));
+            return this;
         }
 
         public Builder<RT, ET> formField(String name, List<String> values) {
-            return formField(name, toCsv(values, true));
+            stateNotNull(formBodyBuilder, "form fields are not accepted by this request.");
+            formBodyBuilder.add(name, toCsv(values, true));
+            return this;
         }
 
         public Builder<RT, ET> body(RequestBody body) {

--- a/api-client/src/main/java/com/xing/api/RealCallSpec.java
+++ b/api-client/src/main/java/com/xing/api/RealCallSpec.java
@@ -203,6 +203,12 @@ final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
     }
 
     @Override
+    public CallSpec<RT, ET> formField(String name, Object value) {
+        builder.formField(name, value);
+        return this;
+    }
+
+    @Override
     public CallSpec<RT, ET> formField(String name, String... values) {
         builder.formField(name, values);
         return this;
@@ -220,7 +226,8 @@ final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
     }
 
     /** Parsers the OkHttp raw response and returns an response ready to be consumed by the caller. */
-    @SuppressWarnings("MagicNumber") // These codes are specific to this method and to the http protocol.
+    @SuppressWarnings("MagicNumber")
+    // These codes are specific to this method and to the http protocol.
     Response<RT, ET> parseResponse(okhttp3.Response rawResponse) throws IOException {
         ResponseBody rawBody = rawResponse.body();
 

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -261,9 +261,12 @@ public class CallSpecTest {
     public void builderAttachesFormFields() throws Exception {
         CallSpec.Builder builder = builder(HttpMethod.PUT, "", true)
               .responseAs(Object.class)
-              .formField("f", "true");
+              .formField("a", "true")
+              .formField("b", 1);
         // Build the CallSpec so that we don't test this behaviour twice.
-        builder.build().formField("e", "false");
+        builder.build()
+              .formField("c", "false")
+              .formField("d", true);
 
         Request request = builder.request();
         assertThat(request.method()).isEqualTo(HttpMethod.PUT.method());
@@ -275,7 +278,29 @@ public class CallSpecTest {
 
         Buffer buffer = new Buffer();
         body.writeTo(buffer);
-        assertThat(buffer.readUtf8()).isEqualTo("f=true&e=false");
+        assertThat(buffer.readUtf8()).isEqualTo("a=true&b=1&c=false&d=true");
+    }
+
+    @Test
+    public void builderEncodesStringFromFields() throws Exception {
+        CallSpec.Builder builder = builder(HttpMethod.PUT, "", true)
+              .responseAs(Object.class)
+              .formField("f", "some_value");
+        // Build the CallSpec so that we don't test this behaviour twice.
+        builder.build().formField("e", "https://www.xing.com/some_path/20533046");
+
+        Request request = builder.request();
+        assertThat(request.method()).isEqualTo(HttpMethod.PUT.method());
+        assertThat(request.url()).isEqualTo(httpUrl);
+        assertThat(request.body()).isNotNull();
+
+        RequestBody body = request.body();
+        assertThat(body.contentType()).isEqualTo(MediaType.parse("application/x-www-form-urlencoded"));
+
+        Buffer buffer = new Buffer();
+        body.writeTo(buffer);
+        assertThat(buffer.readUtf8())
+              .isEqualTo("f=some_value&e=https%253A%252F%252Fwww.xing.com%252Fsome_path%252F20533046");
     }
 
     @Test


### PR DESCRIPTION
This will ensure that form fields passed as strings, are being treated specially
and are properly escaped. For values passed as Object, List, or array
the behavior remains the same.

cc @dhartwich1991 @akreul 
