### PR TITLE
Makes encode optional telling formField explicitly when it should be …

### DIFF
--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -132,13 +132,13 @@ public interface CallSpec<RT, ET> extends Cloneable {
     CallSpec<RT, ET> queryParam(String name, List<String> values);
 
     /**
-     * Adds a form field to the underlying request's form body. The form field value will be encoded if {@code encoded} is
-     * {@code false}, otherwise the value escaped.
+     * Adds a form field to the underlying request's form body. The form field value will be utf-8 encoded if {@code
+     * encode} is {@code true}
      *
      * <p>This will throw an {@linkplain NullPointerException} if the form body support was not specified during spec
      * creation.
      */
-    CallSpec<RT, ET> formField(String name, String value, boolean encoded);
+    CallSpec<RT, ET> formField(String name, String value, boolean encode);
 
     /**
      * Adds a form field to the underlying request's form body.
@@ -289,9 +289,9 @@ public interface CallSpec<RT, ET> extends Cloneable {
             return queryParam(name, toCsv(values, false));
         }
 
-        public Builder<RT, ET> formField(String name, String value, boolean encoded) {
+        public Builder<RT, ET> formField(String name, String value, boolean encode) {
             stateNotNull(formBodyBuilder, "form fields are not accepted by this request.");
-            formBodyBuilder.add(name, encoded ? value : escape(value));
+            formBodyBuilder.add(name, encode ? escape(value) : value);
             return this;
         }
 

--- a/api-client/src/main/java/com/xing/api/RealCallSpec.java
+++ b/api-client/src/main/java/com/xing/api/RealCallSpec.java
@@ -197,8 +197,8 @@ final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
     }
 
     @Override
-    public CallSpec<RT, ET> formField(String name, String value, boolean encoded) {
-        builder.formField(name, value, encoded);
+    public CallSpec<RT, ET> formField(String name, String value, boolean encode) {
+        builder.formField(name, value, encode);
         return this;
     }
 

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -286,12 +286,12 @@ public class CallSpecTest {
     public void builderEncodesStringFromFields() throws Exception {
         CallSpec.Builder builder = builder(HttpMethod.PUT, "", true)
               .responseAs(Object.class)
-              .formField("a", "some_value")
-              .formField("b", "second/value", true);
+              .formField("a", "some_value", true)
+              .formField("b", "second/value");
         // Build the CallSpec so that we don't test this behaviour twice.
         builder.build()
-              .formField("c", "https://www.xing.com/some_path/20533046")
-              .formField("d", "fourth/value", true);
+              .formField("c", "https://www.xing.com/some_path/20533046", true)
+              .formField("d", "fourth/value");
 
         Request request = builder.request();
         assertThat(request.method()).isEqualTo(HttpMethod.PUT.method());


### PR DESCRIPTION
This changes the formField encoding to be optional and to be explicitly enabled by the third parameter.

Dependencies:__
- [x] @serj-lotutovici 
- [x] Unit Tests
