### PR TITLE
Re-define XingApi.Builder.

### DIFF
--- a/api-client-android-sample/src/main/java/com/xing/api/sample/ui/ProfileActivity.java
+++ b/api-client-android-sample/src/main/java/com/xing/api/sample/ui/ProfileActivity.java
@@ -176,6 +176,7 @@ public class ProfileActivity extends BaseActivity {
         @Override
         protected XingUser doInBackground(Activity... params) {
             XingApi api = new XingApi.Builder()
+                  .oauth1()
                   .consumerKey(BuildConfig.OAUTH_CONSUMER_KEY)
                   .consumerSecret(BuildConfig.OAUTH_CONSUMER_SECRET)
                   .accessToken(Prefs.getInstance(ProfileActivity.this).getOauthToken())

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -60,8 +60,8 @@ public class CallSpecTest {
     public void setUp() throws Exception {
         httpUrl = server.url("/");
         mockApi = new XingApi.Builder()
+              .custom()
               .apiEndpoint(httpUrl)
-              .loggedOut()
               .build();
     }
 

--- a/api-client/src/test/java/com/xing/api/internal/json/SafeEnumJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/SafeEnumJsonAdapterTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class SafeEnumJsonAdapterTest {
-    private final Moshi moshi = new XingApi.Builder().loggedOut().build().moshi();
+    private final Moshi moshi = new XingApi.Builder().custom().build().moshi();
 
     @Test
     public void enumAdapter() throws Exception {

--- a/api-client/src/test/java/com/xing/api/resources/ResourceTestCase.java
+++ b/api-client/src/test/java/com/xing/api/resources/ResourceTestCase.java
@@ -15,8 +15,6 @@
  */
 package com.xing.api.resources;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import com.xing.api.CallSpec;
 import com.xing.api.HttpError;
 import com.xing.api.Resource;
@@ -28,6 +26,9 @@ import org.junit.Rule;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,8 +49,8 @@ public class ResourceTestCase<T extends Resource> {
     public void setUp() throws Exception {
         validateResource();
         mockApi = new XingApi.Builder()
+              .custom()
               .apiEndpoint(server.url("/"))
-              .loggedOut()
               .build();
         resource = mockApi.resource(resourceClass);
     }


### PR DESCRIPTION
Separate Builder logic into steps. Define the next steps:
- oauth1() - allows to build the api client in login more (OAuth1)
- loggedOut() - allows to build the api client in logged out mode
- custom() - [Experimental] for internal use.
