### PR TITLE
Add checkstyle rules for JUnit assert methods.

### DIFF
--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -44,7 +44,6 @@ import rx.singles.BlockingSingle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings({"MagicNumber", "ConstantConditions"})
 public class CallSpecTest {
@@ -815,7 +814,7 @@ public class CallSpecTest {
         BlockingObservable<Response<TestMsg, Object>> blocking = spec.rawStream().toBlocking();
         Response<TestMsg, Object> response = blocking.first();
 
-        assertNotNull(response.body());
+        assertThat(response.body()).isNotNull();
         assertThat(response.body().code).isEqualTo(200);
         assertThat(response.body().msg).isEqualTo("success");
     }
@@ -841,7 +840,7 @@ public class CallSpecTest {
         Response<Object, HttpError> response = blocking.first();
 
         assertThat(response.isSuccessful()).isFalse();
-        assertNotNull(response.error());
+        assertThat(response.error()).isNotNull();
         assertThat(response.error().message()).isEqualTo("Terrible Error.");
         assertThat(response.error().name()).isEqualTo("TEST_ERROR");
         assertThat(response.error().errors().get(0))
@@ -1172,7 +1171,7 @@ public class CallSpecTest {
         assertThat(response.headers()).isNotNull();
 
         TestMsg msg = response.body();
-        assertNotNull(msg);
+        assertThat(msg).isNotNull();
         assertThat(msg.msg).isEqualTo(expected.msg);
         assertThat(msg.code).isEqualTo(expected.code);
     }
@@ -1183,7 +1182,7 @@ public class CallSpecTest {
         assertThat(response.body()).isNull();
 
         TestMsg body = response.error();
-        assertNotNull(body);
+        assertThat(body).isNotNull();
         assertThat(body.msg).isEqualTo(expected.msg);
         assertThat(body.code).isEqualTo(expected.code);
     }

--- a/api-client/src/test/java/com/xing/api/ConverterTest.java
+++ b/api-client/src/test/java/com/xing/api/ConverterTest.java
@@ -32,7 +32,6 @@ import okhttp3.ResponseBody;
 import okio.Buffer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -266,14 +265,14 @@ public class ConverterTest {
     @Test
     public void firstAsNullIfListEmpty() throws Exception {
         Type compositeType1 = Converter.first(TestData.class, "empty");
-        assertNull(fromJson(compositeType1, "{\n"
+        assertThat(fromJson(compositeType1, "{\n"
               + "  \"empty\": null\n"
-              + '}'));
+              + '}')).isNull();
 
         Type compositeType2 = Converter.first(TestData.class, "empty");
-        assertNull(fromJson(compositeType2, "{\n"
+        assertThat(fromJson(compositeType2, "{\n"
               + "  \"empty\": []\n"
-              + '}'));
+              + '}')).isNull();
     }
 
     @Test

--- a/api-client/src/test/java/com/xing/api/UrlEscapeUtilsTest.java
+++ b/api-client/src/test/java/com/xing/api/UrlEscapeUtilsTest.java
@@ -18,9 +18,7 @@ package com.xing.api;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -66,10 +64,10 @@ public class UrlEscapeUtilsTest {
         assertUnicodeEscaping("%F0%90%80%80", '\uD800', '\uDC00');
         assertUnicodeEscaping("%F4%8F%BF%BF", '\uDBFF', '\uDFFF');
 
-        assertEquals("", UrlEscapeUtils.escape(""));
-        assertEquals("safestring", UrlEscapeUtils.escape("safestring"));
-        assertEquals("embedded%00null", UrlEscapeUtils.escape("embedded\0null"));
-        assertEquals("max%EF%BF%BFchar", UrlEscapeUtils.escape("max\uffffchar"));
+        assertThat(UrlEscapeUtils.escape("")).isEqualTo("");
+        assertThat(UrlEscapeUtils.escape("safestring")).isEqualTo("safestring");
+        assertThat(UrlEscapeUtils.escape("embedded\0null")).isEqualTo("embedded%00null");
+        assertThat(UrlEscapeUtils.escape("max\uffffchar")).isEqualTo("max%EF%BF%BFchar");
 
         // Specified as safe by RFC 2396 but not by java.net.URLEncoder.
         assertEscaping("%21", '!');
@@ -82,8 +80,8 @@ public class UrlEscapeUtilsTest {
         assertEscaping("%20", ' ');
         assertEscaping("%2B", '+');
 
-        assertEquals("safe%20with%20spaces", UrlEscapeUtils.escape("safe with spaces"));
-        assertEquals("foo%40bar.com", UrlEscapeUtils.escape("foo@bar.com"));
+        assertThat(UrlEscapeUtils.escape("safe with spaces")).isEqualTo("safe%20with%20spaces");
+        assertThat(UrlEscapeUtils.escape("foo@bar.com")).isEqualTo("foo%40bar.com");
     }
 
     /**
@@ -94,8 +92,9 @@ public class UrlEscapeUtilsTest {
      */
     private static void assertEscaping(String expected, char c) {
         String escaped = computeReplacement(c);
-        assertNotNull(escaped);
-        assertEquals(expected, escaped);
+        assertThat(escaped)
+              .isNotNull()
+              .isEqualTo(expected);
     }
 
     /**
@@ -104,7 +103,7 @@ public class UrlEscapeUtilsTest {
      * @param c the character to test
      */
     private static void assertUnescaped(char c) {
-        assertNull(computeReplacement(c));
+        assertThat(computeReplacement(c)).isNull();
     }
 
     /**
@@ -118,8 +117,9 @@ public class UrlEscapeUtilsTest {
     private static void assertUnicodeEscaping(String expected, char hi, char lo) {
         int cp = Character.toCodePoint(hi, lo);
         String escaped = computeReplacement(cp);
-        assertNotNull(escaped);
-        assertEquals(expected, escaped);
+        assertThat(escaped)
+              .isNotNull()
+              .isEqualTo(expected);
     }
 
     private static String computeReplacement(char c) {

--- a/api-client/src/test/java/com/xing/api/XingApiTest.java
+++ b/api-client/src/test/java/com/xing/api/XingApiTest.java
@@ -34,7 +34,6 @@ import okhttp3.mockwebserver.SocketPolicy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -219,7 +218,7 @@ public class XingApiTest {
                 t.printStackTrace();
             }
         });
-        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
 
         verify(executor).execute(any(Runnable.class));
         verifyNoMoreInteractions(executor);
@@ -255,7 +254,7 @@ public class XingApiTest {
                 latch.countDown();
             }
         });
-        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
 
         verify(executor).execute(any(Runnable.class));
         verifyNoMoreInteractions(executor);

--- a/api-client/src/test/java/com/xing/api/data/profile/CompanyTest.java
+++ b/api-client/src/test/java/com/xing/api/data/profile/CompanyTest.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 
 import static org.apache.commons.lang3.StringUtils.leftPad;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Only test methods that represent some functionality. */
@@ -82,18 +80,18 @@ public class CompanyTest {
     @Test
     public void companyReadyToBeAdded() throws Exception {
         Company company = new Company();
-        assertFalse(company.isFilledForAddCompany());
+        assertThat(company.isFilledForAddCompany()).isFalse();
 
         company.name("Test Name");
-        assertFalse(company.isFilledForAddCompany());
+        assertThat(company.isFilledForAddCompany()).isFalse();
 
         company.title("Test Title");
-        assertFalse(company.isFilledForAddCompany());
+        assertThat(company.isFilledForAddCompany()).isFalse();
 
         company.industries(Collections.singletonList(new Industry(22202, "TEST_IND")));
-        assertFalse(company.isFilledForAddCompany());
+        assertThat(company.isFilledForAddCompany()).isFalse();
 
         company.formOfEmployment(FormOfEmployment.PARTNER);
-        assertTrue(company.isFilledForAddCompany());
+        assertThat(company.isFilledForAddCompany()).isTrue();
     }
 }

--- a/api-client/src/test/java/com/xing/api/internal/json/GeoCodeJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/GeoCodeJsonAdapterTest.java
@@ -26,8 +26,6 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 @SuppressWarnings("ConstantConditions")
 public final class GeoCodeJsonAdapterTest {
@@ -35,9 +33,9 @@ public final class GeoCodeJsonAdapterTest {
 
     @Test
     public void ignoresOtherTypes() throws Exception {
-        assertNull(geoCodeAdapter(String.class));
-        assertNull(geoCodeAdapter(Double.class));
-        assertNotNull(geoCodeAdapter(GeoCode.class));
+        assertThat(geoCodeAdapter(String.class)).isNull();
+        assertThat(geoCodeAdapter(Double.class)).isNull();
+        assertThat(geoCodeAdapter(GeoCode.class)).isNotNull();
     }
 
     @Test
@@ -61,11 +59,11 @@ public final class GeoCodeJsonAdapterTest {
     public void ignoresInvalidGeoCode() throws Exception {
         JsonAdapter<GeoCode> adapter = geoCodeAdapter(GeoCode.class);
 
-        assertNull(adapter.fromJson("{\"accuracy\":12,\"latitude\":null,\"longitude\":null}"));
-        assertNull(adapter.fromJson("{\"latitude\":34.2,\"longitude\":null}"));
-        assertNull(adapter.fromJson("{\"latitude\":null,\"longitude\":24.45}"));
-        assertNull(adapter.fromJson("{\"unknown\":null,\"longitude\":24.45}"));
-        assertNull(adapter.fromJson("{}"));
+        assertThat(adapter.fromJson("{\"accuracy\":12,\"latitude\":null,\"longitude\":null}")).isNull();
+        assertThat(adapter.fromJson("{\"latitude\":34.2,\"longitude\":null}")).isNull();
+        assertThat(adapter.fromJson("{\"latitude\":null,\"longitude\":24.45}")).isNull();
+        assertThat(adapter.fromJson("{\"unknown\":null,\"longitude\":24.45}")).isNull();
+        assertThat(adapter.fromJson("{}")).isNull();
     }
 
     @SuppressWarnings("unchecked") // It's the callers responsibility.

--- a/api-client/src/test/java/com/xing/api/internal/json/PhoneJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/PhoneJsonAdapterTest.java
@@ -27,7 +27,6 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -41,13 +40,13 @@ public class PhoneJsonAdapterTest {
     public void ignoresOtherTypes() throws Exception {
         JsonAdapter<?> adapter1 = PhoneJsonAdapter.FACTORY.create(
               String.class, Collections.<Annotation>emptySet(), moshi);
-        assertNull(adapter1);
+        assertThat(adapter1).isNull();
 
         Set<Annotation> annotations = new LinkedHashSet<>(1);
         annotations.add(mock(Annotation.class));
         JsonAdapter<?> adapter2 = PhoneJsonAdapter.FACTORY.create(
               Phone.class, annotations, moshi);
-        assertNull(adapter2);
+        assertThat(adapter2).isNull();
     }
 
     @Test

--- a/api-client/src/test/java/com/xing/api/internal/json/SafeCalendarJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/SafeCalendarJsonAdapterTest.java
@@ -34,10 +34,6 @@ import java.util.TimeZone;
 
 import static com.xing.api.internal.json.SafeCalendarJsonAdapter.ZULU_TIME_ZONE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -63,18 +59,18 @@ public final class SafeCalendarJsonAdapterTest {
     public void ignoresOtherTypes() throws Exception {
         JsonAdapter<?> adapter1 = SafeCalendarJsonAdapter.FACTORY.create(
               String.class, Collections.<Annotation>emptySet(), moshi);
-        assertNull(adapter1);
+        assertThat(adapter1).isNull();
 
         Set<Annotation> annotations = new LinkedHashSet<>(1);
         annotations.add(mock(Annotation.class));
         JsonAdapter<?> adapter2 = SafeCalendarJsonAdapter.FACTORY.create(
               Calendar.class, annotations, moshi);
-        assertNull(adapter2);
+        assertThat(adapter2).isNull();
     }
 
     @Test
     public void nullIfEmpty() throws Exception {
-        assertNull(calendarAdapter().fromJson("\"\""));
+        assertThat(calendarAdapter().fromJson("\"\"")).isNull();
     }
 
     @Test
@@ -97,11 +93,11 @@ public final class SafeCalendarJsonAdapterTest {
         assertThat(toJson).isEqualTo("\"2031\"");
 
         Calendar fromJson = calendarAdapter().fromJson("\"1956\"");
-        assertNotNull(fromJson);
+        assertThat(fromJson).isNotNull();
 
-        assertFalse(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertFalse(fromJson.isSet(Calendar.MONTH));
-        assertTrue(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isFalse();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isFalse();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(1956);
     }
@@ -116,11 +112,11 @@ public final class SafeCalendarJsonAdapterTest {
         assertThat(toJson).isEqualTo("\"1987-08\"");
 
         Calendar fromJson = calendarAdapter().fromJson("\"1945-05\"");
-        assertNotNull(fromJson);
+        assertThat(fromJson).isNotNull();
 
-        assertFalse(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson.isSet(Calendar.MONTH));
-        assertTrue(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isFalse();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(1945);
         assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.MAY);
@@ -136,11 +132,11 @@ public final class SafeCalendarJsonAdapterTest {
         assertThat(toJson).isEqualTo("\"10-14\"");
 
         Calendar fromJson = calendarAdapter().fromJson("\"03-05\"");
-        assertNotNull(fromJson);
+        assertThat(fromJson).isNotNull();
 
-        assertTrue(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson.isSet(Calendar.MONTH));
-        assertFalse(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isFalse();
 
         assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.MARCH);
         assertThat(fromJson.get(Calendar.DAY_OF_MONTH)).isEqualTo(5);
@@ -157,11 +153,11 @@ public final class SafeCalendarJsonAdapterTest {
         assertThat(toJson).isEqualTo("\"1991-12-31\"");
 
         Calendar fromJson = calendarAdapter().fromJson("\"1988-03-04\"");
-        assertNotNull(fromJson);
+        assertThat(fromJson).isNotNull();
 
-        assertTrue(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson.isSet(Calendar.MONTH));
-        assertTrue(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(1988);
         assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.MARCH);
@@ -183,14 +179,14 @@ public final class SafeCalendarJsonAdapterTest {
         assertThat(toJson).isEqualTo("\"2011-01-23T20:20:17Z\"");
 
         Calendar fromJson = calendarAdapter().fromJson("\"2000-02-27T23:00:23Z\"");
-        assertNotNull(fromJson);
+        assertThat(fromJson).isNotNull();
 
-        assertTrue(fromJson.isSet(Calendar.SECOND));
-        assertTrue(fromJson.isSet(Calendar.MINUTE));
-        assertTrue(fromJson.isSet(Calendar.HOUR_OF_DAY));
-        assertTrue(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson.isSet(Calendar.MONTH));
-        assertTrue(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.SECOND)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MINUTE)).isTrue();
+        assertThat(fromJson.isSet(Calendar.HOUR_OF_DAY)).isTrue();
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(2000);
         assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.FEBRUARY);
@@ -203,14 +199,14 @@ public final class SafeCalendarJsonAdapterTest {
     @Test
     public void iso8601withTimeZone() throws Exception {
         Calendar fromJson = calendarAdapter().fromJson("\"2000-02-27T23:00:23+0200\"");
-        assertNotNull(fromJson);
+        assertThat(fromJson).isNotNull();
 
-        assertTrue(fromJson.isSet(Calendar.SECOND));
-        assertTrue(fromJson.isSet(Calendar.MINUTE));
-        assertTrue(fromJson.isSet(Calendar.HOUR));
-        assertTrue(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson.isSet(Calendar.MONTH));
-        assertTrue(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.SECOND)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MINUTE)).isTrue();
+        assertThat(fromJson.isSet(Calendar.HOUR)).isTrue();
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(2000);
         assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.FEBRUARY);
@@ -226,22 +222,22 @@ public final class SafeCalendarJsonAdapterTest {
         Calendar fromJson1 = calendarAdapter().fromJson("\"2003-04-21T16:42:11+02:00\"");
         Calendar fromJson2 = calendarAdapter().fromJson("\"2016-07-21T17:59:59-04:00\"");
 
-        assertNotNull(fromJson1);
-        assertNotNull(fromJson2);
+        assertThat(fromJson1).isNotNull();
+        assertThat(fromJson2).isNotNull();
 
-        assertTrue(fromJson1.isSet(Calendar.SECOND));
-        assertTrue(fromJson1.isSet(Calendar.MINUTE));
-        assertTrue(fromJson1.isSet(Calendar.HOUR));
-        assertTrue(fromJson1.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson1.isSet(Calendar.MONTH));
-        assertTrue(fromJson1.isSet(Calendar.YEAR));
+        assertThat(fromJson1.isSet(Calendar.SECOND)).isTrue();
+        assertThat(fromJson1.isSet(Calendar.MINUTE)).isTrue();
+        assertThat(fromJson1.isSet(Calendar.HOUR)).isTrue();
+        assertThat(fromJson1.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson1.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson1.isSet(Calendar.YEAR)).isTrue();
 
-        assertTrue(fromJson2.isSet(Calendar.SECOND));
-        assertTrue(fromJson2.isSet(Calendar.MINUTE));
-        assertTrue(fromJson2.isSet(Calendar.HOUR));
-        assertTrue(fromJson2.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson2.isSet(Calendar.MONTH));
-        assertTrue(fromJson2.isSet(Calendar.YEAR));
+        assertThat(fromJson2.isSet(Calendar.SECOND)).isTrue();
+        assertThat(fromJson2.isSet(Calendar.MINUTE)).isTrue();
+        assertThat(fromJson2.isSet(Calendar.HOUR)).isTrue();
+        assertThat(fromJson2.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson2.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson2.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson1.get(Calendar.YEAR)).isEqualTo(2003);
         assertThat(fromJson1.get(Calendar.MONTH)).isEqualTo(Calendar.APRIL);
@@ -263,14 +259,14 @@ public final class SafeCalendarJsonAdapterTest {
     @Test
     public void iso8601withMilliseconds() throws Exception {
         Calendar fromJson = calendarAdapter().fromJson("\"2016-01-15T07:42:01.000Z\"");
-        assertNotNull(fromJson);
+        assertThat(fromJson).isNotNull();
 
-        assertTrue(fromJson.isSet(Calendar.SECOND));
-        assertTrue(fromJson.isSet(Calendar.MINUTE));
-        assertTrue(fromJson.isSet(Calendar.HOUR));
-        assertTrue(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson.isSet(Calendar.MONTH));
-        assertTrue(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.SECOND)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MINUTE)).isTrue();
+        assertThat(fromJson.isSet(Calendar.HOUR)).isTrue();
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(2016);
         assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.JANUARY);
@@ -285,13 +281,13 @@ public final class SafeCalendarJsonAdapterTest {
         Calendar fromJson = calendarAdapter().fromJson("\"2014-04-30T10:53:48.000+02:00\"");
         assertThat(fromJson).isNotNull();
 
-        assertTrue(fromJson.isSet(Calendar.MILLISECOND));
-        assertTrue(fromJson.isSet(Calendar.SECOND));
-        assertTrue(fromJson.isSet(Calendar.MINUTE));
-        assertTrue(fromJson.isSet(Calendar.HOUR));
-        assertTrue(fromJson.isSet(Calendar.DAY_OF_MONTH));
-        assertTrue(fromJson.isSet(Calendar.MONTH));
-        assertTrue(fromJson.isSet(Calendar.YEAR));
+        assertThat(fromJson.isSet(Calendar.MILLISECOND)).isTrue();
+        assertThat(fromJson.isSet(Calendar.SECOND)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MINUTE)).isTrue();
+        assertThat(fromJson.isSet(Calendar.HOUR)).isTrue();
+        assertThat(fromJson.isSet(Calendar.DAY_OF_MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.MONTH)).isTrue();
+        assertThat(fromJson.isSet(Calendar.YEAR)).isTrue();
 
         assertThat(fromJson.get(Calendar.YEAR)).isEqualTo(2014);
         assertThat(fromJson.get(Calendar.MONTH)).isEqualTo(Calendar.APRIL);
@@ -312,7 +308,7 @@ public final class SafeCalendarJsonAdapterTest {
 
         //noinspection SSBasedInspection
         for (TimeZone currentTimeZone : parsedTimeZones) {
-            assertTrue(ZULU_TIME_ZONE.equals(currentTimeZone));
+            assertThat(ZULU_TIME_ZONE.equals(currentTimeZone)).isTrue();
         }
     }
 

--- a/api-client/src/test/java/com/xing/api/internal/json/TimeZoneJsonAdapterTest.java
+++ b/api-client/src/test/java/com/xing/api/internal/json/TimeZoneJsonAdapterTest.java
@@ -26,17 +26,15 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 public final class TimeZoneJsonAdapterTest {
     private final Moshi moshi = new Moshi.Builder().build();
 
     @Test
     public void ignoresOtherTypes() throws Exception {
-        assertNull(timeZoneAdapter(String.class));
-        assertNull(timeZoneAdapter(Double.class));
-        assertNotNull(timeZoneAdapter(TimeZone.class));
+        assertThat(timeZoneAdapter(String.class)).isNull();
+        assertThat(timeZoneAdapter(Double.class)).isNull();
+        assertThat(timeZoneAdapter(TimeZone.class)).isNotNull();
     }
 
     @Test
@@ -58,10 +56,10 @@ public final class TimeZoneJsonAdapterTest {
     public void ignoresInvalidTimeZone() throws Exception {
         JsonAdapter<TimeZone> adapter = timeZoneAdapter(TimeZone.class);
 
-        assertNull(adapter.fromJson("{\"name\":\"hey\",\"utc_offset\":null}"));
-        assertNull(adapter.fromJson("{\"name\":null,\"utc_offset\":null}"));
-        assertNull(adapter.fromJson("{\"latitude\":null,\"longitude\":24.45}"));
-        assertNull(adapter.fromJson("{}"));
+        assertThat(adapter.fromJson("{\"name\":\"hey\",\"utc_offset\":null}")).isNull();
+        assertThat(adapter.fromJson("{\"name\":null,\"utc_offset\":null}")).isNull();
+        assertThat(adapter.fromJson("{\"latitude\":null,\"longitude\":24.45}")).isNull();
+        assertThat(adapter.fromJson("{}")).isNull();
     }
 
     @SuppressWarnings("unchecked") // It's the callers responsibility.

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ subprojects { project ->
     task checkstyle(type: Checkstyle) {
         group 'verification'
         configFile rootProject.file('checkstyle.xml')
-        source = ['src/main/java', 'src/test/java']
+        source = ['src']
 
         ignoreFailures false
         showViolations true

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -142,5 +142,49 @@
         <!--module name="FinalParameters"/-->
         <!--module name="TodoComment"/-->
         <module name="UpperEll" />
+
+        <!-- Custom checks for JUnit's Assert usage.       -->
+        <!-- From https://gist.github.com/vanniktech/e8117fb245e804971a83288c1498c9d7 -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="import static org\.junit\.Assert\.assertEquals;"/>
+            <property name="message"
+                value="Don't use JUnits assertEquals, AssertJ is preferred: assertThat(foo).isEqualTo();"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="import static org\.junit\.Assert\.assertNotEquals;"/>
+            <property name="message"
+                value="Don't use JUnits assertNotEquals, AssertJ is preferred: assertThat(foo).isNotEqualTo();"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="import static org\.junit\.Assert\.assertSame;"/>
+            <property name="message"
+                value="Don't use JUnits assertSame, AssertJ is preferred: assertThat(foo).isSameAs();"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="import static org\.junit\.Assert\.assertNull;"/>
+            <property name="message"
+                value="Don't use JUnits assertNull, AssertJ is preferred: assertThat(foo).isNull()"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="import static org\.junit\.Assert\.assertNotNull;"/>
+            <property name="message"
+                value="Don't use JUnits assertNotNull, AssertJ is preferred: assertThat(foo).isNotNull()"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="import static org\.junit\.Assert\.assertTrue;"/>
+            <property name="message"
+                value="Don't use JUnits assertTrue, AssertJ is preferred: assertThat(foo).isTrue()"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="import static org\.junit\.Assert\.assertFalse;"/>
+            <property name="message"
+                value="Don't use JUnits assertFalse, AssertJ is preferred: assertThat(foo).isFalse()"/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
Avoid using `JUnit.assert*`, prefer AssertJ's `assertThat()`!

Dependencies:__
- [x] Updated unit tests
