### PR TITLE
Introduce per-call configurable read and connect timeouts

### DIFF
--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -330,8 +330,8 @@ public interface CallSpec<RT, ET> extends Cloneable {
         }
 
         public Builder<RT, ET> timeouts(int connectTimeout, int readTimeout) {
-            if (connectTimeout < 0 || readTimeout < 0) {
-                throw new IllegalArgumentException("timeouts must be positive");
+            if (connectTimeout <= 0 || readTimeout <= 0) {
+                throw new IllegalArgumentException("timeouts must be > 0");
             }
             this.connectTimeout = connectTimeout;
             this.readTimeout = readTimeout;

--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -172,6 +172,13 @@ public interface CallSpec<RT, ET> extends Cloneable {
      */
     CallSpec<RT, ET> formField(String name, List<String> values);
 
+    /**
+     * Overrides the connection's default timeouts for this particular call.
+     *
+     * All timeouts in seconds.
+     */
+    CallSpec<RT, ET> timeouts(int connectTimeout, int readTimeout);
+
     /** Creates and returns a copy of <strong>this</strong> object losing the executable state. */
     CallSpec<RT, ET> clone();
 
@@ -215,6 +222,8 @@ public interface CallSpec<RT, ET> extends Cloneable {
         final XingApi api;
         Type responseType;
         Type errorType;
+        int connectTimeout;
+        int readTimeout;
 
         // For now block the possibility to build outside this package.
         Builder(XingApi api, HttpMethod httpMethod, String resourcePath, boolean isFormEncoded) {
@@ -241,6 +250,8 @@ public interface CallSpec<RT, ET> extends Cloneable {
             body = builder.body;
             responseType = builder.responseType;
             errorType = builder.errorType;
+            readTimeout = builder.readTimeout;
+            connectTimeout = builder.connectTimeout;
         }
 
         /** Replaces path parameter {@code name} with provided {@code values}. */
@@ -315,6 +326,15 @@ public interface CallSpec<RT, ET> extends Cloneable {
         public Builder<RT, ET> formField(String name, List<String> values) {
             stateNotNull(formBodyBuilder, "form fields are not accepted by this request.");
             formBodyBuilder.add(name, toCsv(values, true));
+            return this;
+        }
+
+        public Builder<RT, ET> timeouts(int connectTimeout, int readTimeout) {
+            if (connectTimeout < 0 || readTimeout < 0) {
+                throw new IllegalArgumentException("timeouts must be positive");
+            }
+            this.connectTimeout = connectTimeout;
+            this.readTimeout = readTimeout;
             return this;
         }
 

--- a/api-client/src/main/java/com/xing/api/RealCallSpec.java
+++ b/api-client/src/main/java/com/xing/api/RealCallSpec.java
@@ -53,8 +53,8 @@ final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
     private volatile Call rawCall;
     private boolean executed; // Guarded by this.
     private volatile boolean canceled;
-    private int connectTimeout = -1;
-    private int readTimeout = -1;
+    private int connectTimeout;
+    private int readTimeout;
 
     RealCallSpec(CallSpec.Builder<RT, ET> builder) {
         this.builder = builder;
@@ -237,6 +237,7 @@ final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
         return this;
     }
 
+    /** timeouts in seconds >0 */
     @Override public CallSpec<RT, ET> timeouts(int connectTimeout, int readTimeout) {
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
@@ -246,7 +247,7 @@ final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
     /** Returns a raw {@link Call} pre-building the targeted request. */
     private Call createRawCall() {
         OkHttpClient client = api.client();
-        if (readTimeout != -1 && connectTimeout != -1) {
+        if (readTimeout > 0 && connectTimeout > 0) {
             client = client.newBuilder()
                   .connectTimeout(connectTimeout, TimeUnit.SECONDS)
                   .readTimeout(readTimeout, TimeUnit.SECONDS)

--- a/api-client/src/main/java/com/xing/api/RealCallSpec.java
+++ b/api-client/src/main/java/com/xing/api/RealCallSpec.java
@@ -237,7 +237,7 @@ final class RealCallSpec<RT, ET> implements CallSpec<RT, ET> {
         return this;
     }
 
-    /** timeouts in seconds >0 */
+    /** Timeouts in seconds >0. */
     @Override public CallSpec<RT, ET> timeouts(int connectTimeout, int readTimeout) {
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -15,14 +15,17 @@
  */
 package com.xing.api;
 
+import com.xing.api.CallSpec.Builder;
 import com.xing.api.HttpError.Error.Reason;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -34,10 +37,13 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
 import okio.Buffer;
+import rx.Observable;
 import rx.observables.BlockingObservable;
 import rx.observers.TestSubscriber;
 import rx.singles.BlockingSingle;
@@ -51,6 +57,8 @@ public class CallSpecTest {
     public final MockWebServer server = new MockWebServer();
     @Rule
     public final RecordingSubscriber.Rule subscriberRule = new RecordingSubscriber.Rule();
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     public XingApi mockApi;
     public HttpUrl httpUrl;
@@ -574,7 +582,7 @@ public class CallSpecTest {
               .build();
 
         Response<Object, TestMsg> response = spec.execute();
-        assertEnmptyErrorResponse(response, 300);
+        assertEmptyErrorResponse(response, 300);
     }
 
     @Test
@@ -1164,6 +1172,49 @@ public class CallSpecTest {
         assertThat(exception).hasMessage("401 Unauthorized");
     }
 
+    @Test
+    public void canOverrideReadAndConnectTimeoutPerCall() throws Exception {
+        // we cannot test the connect timeout, because MockWebServer immediately accepts connections
+        // and provides no callback to delay this, but we can emulate a read timeout by stalling the response
+        // indefinitely
+        server.setDispatcher(new Dispatcher() {
+            @Override public MockResponse dispatch(RecordedRequest request) {
+                return new MockResponse().setResponseCode(200).setSocketPolicy(SocketPolicy.NO_RESPONSE);
+            }
+        });
+
+        // all in seconds
+        int readTimeout = 1;
+        int ignoredConnectTimeout = 10;
+        // the estimated execution time on the client side, plus a buffer
+        // of some milliseconds in case we're slower
+        int executionTime = 200;
+
+        Builder<ResponseBody, Object> builder = builder(HttpMethod.GET, "", false);
+        Observable<Response<ResponseBody, Object>> stream =
+              builder.responseAs(ResponseBody.class).timeouts(ignoredConnectTimeout, readTimeout)
+                    .build().rawStream();
+
+        TestSubscriber<Response<ResponseBody, Object>> testSubscriber = new TestSubscriber<>();
+
+        long before = System.currentTimeMillis();
+        stream.subscribe(testSubscriber);
+        long diff = System.currentTimeMillis() - before;
+
+        testSubscriber.assertError(SocketTimeoutException.class);
+        assertThat(diff).isLessThan((readTimeout * 1000) + executionTime);
+    }
+
+    @Test
+    public void disallowNegativeTimeouts() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        builder(HttpMethod.GET, "", false)
+              .responseAs(Object.class)
+              .timeouts(-1, -1);
+    }
+
+    // region - assertions
+
     private static void assertSuccessResponse(Response<TestMsg, Object> response, TestMsg expected) {
         assertThat(response.code()).isEqualTo(200);
         assertThat(response.error()).isNull();
@@ -1187,7 +1238,7 @@ public class CallSpecTest {
         assertThat(body.code).isEqualTo(expected.code);
     }
 
-    private static void assertEnmptyErrorResponse(Response<Object, TestMsg> response, int code) {
+    private static void assertEmptyErrorResponse(Response<Object, TestMsg> response, int code) {
         assertThat(response.isSuccessful()).isFalse();
         assertThat(response.code()).isEqualTo(code);
         assertThat(response.body()).isNull();
@@ -1248,9 +1299,15 @@ public class CallSpecTest {
         assertNoBodySuccessResponse(responseRef.get(), code);
     }
 
+    // endregion
+
+    // region - creators
+
     private <RT, ET> CallSpec.Builder<RT, ET> builder(HttpMethod httpMethod, String path, boolean formEncoded) {
         return new CallSpec.Builder<>(mockApi, httpMethod, path, formEncoded);
     }
+
+    // endregion
 
     static final class TestMsg {
         final String msg;

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -1206,14 +1206,12 @@ public class CallSpecTest {
     }
 
     @Test
-    public void disallowNegativeTimeouts() throws Exception {
+    public void disallowZeroOrNegativeTimeouts() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         builder(HttpMethod.GET, "", false)
               .responseAs(Object.class)
-              .timeouts(-1, -1);
+              .timeouts(0, -1);
     }
-
-    // region - assertions
 
     private static void assertSuccessResponse(Response<TestMsg, Object> response, TestMsg expected) {
         assertThat(response.code()).isEqualTo(200);
@@ -1299,15 +1297,9 @@ public class CallSpecTest {
         assertNoBodySuccessResponse(responseRef.get(), code);
     }
 
-    // endregion
-
-    // region - creators
-
     private <RT, ET> CallSpec.Builder<RT, ET> builder(HttpMethod httpMethod, String path, boolean formEncoded) {
         return new CallSpec.Builder<>(mockApi, httpMethod, path, formEncoded);
     }
-
-    // endregion
 
     static final class TestMsg {
         final String msg;


### PR DESCRIPTION
It's now possible to configure read / connect timeouts per call. These override the global read / connect timeouts by building a specific OkHttpClient just for that call just before executing it. This is useful for big payloads that need to be transported over the API.

__Issue:__ n/a

Dependencies:__
- [x] Unit Tests
