### PR TITLE
Bump gradle and build tools to fix some packaging issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-23.0.3
-    - android-23
+    - build-tools-27.0.3
+    - android-26
     - extra-android-m2repository
     - extra-android-support
 

--- a/api-client-android-oauth/build.gradle
+++ b/api-client-android-oauth/build.gradle
@@ -64,7 +64,8 @@ dependencies {
     }
 
     provided libraries.supportAnnotations
-    provided libraries.supportV4
+
+    compile libraries.supportV4
     compile libraries.singpost
 
     testCompile libraries.junit

--- a/api-client/build.gradle
+++ b/api-client/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     compile libraries.okhttp
     compile libraries.moshi
     compile libraries.moshiLazyAdapters
+
     kapt libraries.moshiKotlinCodegen
 
     testCompile libraries.mockWebServer
@@ -77,7 +78,7 @@ ext {
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
 buildscript {
-    ext.kotlin_version = '1.2.10'
+    ext.kotlin_version = '1.2.50'
     repositories {
         mavenCentral()
     }

--- a/api-client/src/test/java/com/xing/api/MoshiRule.kt
+++ b/api-client/src/test/java/com/xing/api/MoshiRule.kt
@@ -1,0 +1,38 @@
+package com.xing.api
+
+import com.serjltt.moshi.adapters.FallbackEnum
+import com.squareup.moshi.Moshi
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import com.serjltt.moshi.adapters.FallbackOnNull
+import com.xing.api.internal.json.*
+
+class MoshiRule : TestRule {
+
+    lateinit var moshi: Moshi
+
+    override fun apply(base: Statement, description: Description) = object : Statement() {
+        override fun evaluate() {
+            moshi = buildMoshi()
+            base.evaluate()
+        }
+    }
+
+    internal fun buildMoshi(): Moshi {
+        return Moshi.Builder()
+                .add(FallbackOnNull.ADAPTER_FACTORY)
+                .add(FallbackEnum.ADAPTER_FACTORY)
+                .add(SafeEnumJsonAdapter.FACTORY)
+                .add(ContactPathJsonAdapter.FACTORY)
+                .add(BirthDateJsonAdapter.FACTORY)
+                .add(SafeCalendarJsonAdapter.FACTORY)
+                .add(PhoneJsonAdapter.FACTORY)
+                .add(CsvCollectionJsonAdapter.FACTORY)
+                .add(GeoCodeJsonAdapter.FACTORY)
+                .add(TimeZoneJsonAdapter.FACTORY)
+                .add(ContactPathJsonAdapter.FACTORY)
+                .add(SafeCalendarJsonAdapter.FACTORY)
+                .build()
+    }
+}

--- a/api-client/src/test/java/com/xing/api/data/contact/ContactPathsTest.kt
+++ b/api-client/src/test/java/com/xing/api/data/contact/ContactPathsTest.kt
@@ -1,0 +1,32 @@
+package com.xing.api.data.contact
+
+import com.xing.api.MoshiRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class ContactPathsTest {
+
+    @JvmField @Rule
+    val moshiRule = MoshiRule()
+
+    private val contactPathsJson = """
+            {
+                "paths": [],
+                "distance": 0,
+                "total": 0
+            }
+        """
+
+    @Test
+    fun `converts json response to the expected contact paths model`() {
+        val expectedContactPaths = ContactPaths(
+                paths = emptyList(),
+                distance = 0,
+                total = 0
+        )
+        with(moshiRule.moshi.adapter(ContactPaths::class.java)) {
+            assertThat(fromJson(contactPathsJson)).isEqualTo(expectedContactPaths)
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,10 @@ buildscript {
         maven {
             url 'https://plugins.gradle.org/m2/'
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.9'
     }
 }
@@ -30,17 +31,18 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        google()
     }
 
     project.ext {
         /** Contains global constants shared with all modules. */
         versions = [
-              androidCompileSdk: 23,
-              androidBuildTools: '23.0.3',
+              androidCompileSdk: 26,
+              androidBuildTools: '27.0.3',
               androidMinSdk    : 14,
               androidTargetSdk : 23,
 
-              androidSupportLib: '23.1.0',
+              androidSupportLib: '27.1.1',
               okHttp           : '3.10.0',
               kotlin_version   : '1.2.10',
               moshiVersion     : '1.6.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP_ID=com.xing.api
-VERSION=3.0.4
+VERSION=3.0.5
 VERSION_CODE=14
 
 POM_DESCRIPTION=XING API Client for Java/Android

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 08 12:12:33 CET 2018
+#Mon Jun 25 17:16:27 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip


### PR DESCRIPTION
Generated moshi `ContactPaths` adapter wasn't really generated (and included in library's packaging) sometimes. 

After an investigation I found out that the old support Gradle version and build tools could be the cause, so I've bumped them and add an unit test to verify the conversion.

__Other actions:__
* Bump Kotlin to latest version
* Add moshi rule to instantiate a moshi's instance for unit testing
* Bump api-client to 3.0.5

__Dependencies:__
- [x] Unit Tests
