### PR TITLE
Allow setting a hostname verifier

### DIFF
--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -30,7 +30,6 @@ import javax.net.ssl.HostnameVerifier;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
-import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
@@ -189,7 +188,7 @@ public interface CallSpec<RT, ET> extends Cloneable {
     CallSpec<RT, ET> writeTimeout(int writeTimeout);
 
     /**
-     * Overrides the HTTP client's hostname verifier
+     * Overrides the HTTP client's hostname verifier.
      */
     CallSpec<RT, ET> hostnameVerifier(HostnameVerifier hostnameVerifier);
 

--- a/api-client/src/main/java/com/xing/api/CallSpec.java
+++ b/api-client/src/main/java/com/xing/api/CallSpec.java
@@ -26,8 +26,11 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.HostnameVerifier;
+
 import io.reactivex.Completable;
 import io.reactivex.Single;
+import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
@@ -185,6 +188,11 @@ public interface CallSpec<RT, ET> extends Cloneable {
      */
     CallSpec<RT, ET> writeTimeout(int writeTimeout);
 
+    /**
+     * Overrides the HTTP client's hostname verifier
+     */
+    CallSpec<RT, ET> hostnameVerifier(HostnameVerifier hostnameVerifier);
+
     /** Creates and returns a copy of <strong>this</strong> object losing the executable state. */
     CallSpec<RT, ET> clone();
 
@@ -231,6 +239,7 @@ public interface CallSpec<RT, ET> extends Cloneable {
         int connectTimeout = -1;
         int readTimeout = -1;
         int writeTimeout = -1;
+        HostnameVerifier hostnameVerifier;
 
         // For now block the possibility to build outside this package.
         Builder(XingApi api, HttpMethod httpMethod, String resourcePath, boolean isFormEncoded) {
@@ -260,6 +269,7 @@ public interface CallSpec<RT, ET> extends Cloneable {
             connectTimeout = builder.connectTimeout;
             readTimeout = builder.readTimeout;
             writeTimeout = builder.writeTimeout;
+            hostnameVerifier = builder.hostnameVerifier;
         }
 
         /** Replaces path parameter {@code name} with provided {@code values}. */
@@ -361,6 +371,11 @@ public interface CallSpec<RT, ET> extends Cloneable {
                 throw new IllegalArgumentException("timeout must be >= 0");
             }
             this.writeTimeout = writeTimeout;
+            return this;
+        }
+
+        public Builder<RT, ET> hostnameVerifier(HostnameVerifier hostnameVerifier) {
+            this.hostnameVerifier = hostnameVerifier;
             return this;
         }
 

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -501,10 +501,10 @@ public class CallSpecTest {
                 .apiEndpoint(httpUrl)
                 .build();
 
-        HostnameVerifier noGoogleVerifier = new HostnameVerifier() {
+        HostnameVerifier failingVerifier = new HostnameVerifier() {
             @Override
             public boolean verify(String host, SSLSession sslSession) {
-                return !host.contains("google");
+                return false;
             }
         };
 
@@ -513,7 +513,7 @@ public class CallSpecTest {
         this.<Void, Void>builder(HttpMethod.GET, "/", false)
                 .responseAs(Void.class)
                 .errorAs(Void.class)
-                .hostnameVerifier(noGoogleVerifier)
+                .hostnameVerifier(failingVerifier)
                 .build()
                 .completableResponse()
                 .test()
@@ -528,10 +528,10 @@ public class CallSpecTest {
                 .apiEndpoint(httpUrl)
                 .build();
 
-        HostnameVerifier onlyGoogleVerifier = new HostnameVerifier() {
+        HostnameVerifier succeedingVerifier = new HostnameVerifier() {
             @Override
             public boolean verify(String host, SSLSession sslSession) {
-                return host.contains("google");
+                return true;
             }
         };
 
@@ -540,7 +540,7 @@ public class CallSpecTest {
         this.<Void, Void>builder(HttpMethod.GET, "/", false)
               .responseAs(Void.class)
               .errorAs(Void.class)
-              .hostnameVerifier(onlyGoogleVerifier)
+              .hostnameVerifier(succeedingVerifier)
               .build()
               .completableResponse()
               .test()

--- a/api-client/src/test/java/com/xing/api/CallSpecTest.java
+++ b/api-client/src/test/java/com/xing/api/CallSpecTest.java
@@ -32,6 +32,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
 import io.reactivex.Single;
 import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
@@ -487,6 +491,60 @@ public class CallSpecTest {
 
         Response<TestMsg, Object> response = spec.execute();
         assertSuccessResponse(response, new TestMsg("success", 42));
+    }
+
+    @Test
+    public void specFailsWhenHostnameVerifierCannotVerify() {
+        // Custom url is required to have `https`
+        httpUrl = server.url("https://www.google.com");
+        mockApi = new XingApi.Builder().custom()
+                .apiEndpoint(httpUrl)
+                .build();
+
+        HostnameVerifier noGoogleVerifier = new HostnameVerifier() {
+            @Override
+            public boolean verify(String host, SSLSession sslSession) {
+                return !host.contains("google");
+            }
+        };
+
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        this.<Void, Void>builder(HttpMethod.GET, "/", false)
+                .responseAs(Void.class)
+                .errorAs(Void.class)
+                .hostnameVerifier(noGoogleVerifier)
+                .build()
+                .completableResponse()
+                .test()
+                .assertError(SSLPeerUnverifiedException.class);
+    }
+
+    @Test
+    public void specSucceedsWhenHostnameVerifierVerifies() {
+        // Custom url is required to have `https`
+        httpUrl = server.url("https://www.google.com");
+        mockApi = new XingApi.Builder().custom()
+                .apiEndpoint(httpUrl)
+                .build();
+
+        HostnameVerifier onlyGoogleVerifier = new HostnameVerifier() {
+            @Override
+            public boolean verify(String host, SSLSession sslSession) {
+                return host.contains("google");
+            }
+        };
+
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        this.<Void, Void>builder(HttpMethod.GET, "/", false)
+              .responseAs(Void.class)
+              .errorAs(Void.class)
+              .hostnameVerifier(onlyGoogleVerifier)
+              .build()
+              .completableResponse()
+              .test()
+              .assertNoErrors();
     }
 
     @Test


### PR DESCRIPTION
<!--- 
First of all, thank you for contributing to our project. 
Please make sure to fill out the form below so we can get a glimpse of what this PR does.
Note that if you decide not to include this information we may close your PR. 
-->

This pull request makes the hostname verifier of the internal _OkHttp_ client publicly settable. 

We needed to handle certificate verification on our own and were otherwise not able to intercept validation.

We tried adding a test by changing the behaviour of the [MockWebServer](https://github.com/xing/xing-android-sdk/blob/master/api-client/src/test/java/com/xing/api/CallSpecTest.java#L60) so that it would challenge the client when a request is sent.

We had a test similar to the existing ones in [CallSpecTest](https://github.com/xing/xing-android-sdk/blob/master/api-client/src/test/java/com/xing/api/CallSpecTest.java) and attempted something like this:

```
set a hostname verifier on a CallSpec
make mockWebServer perform a certificate challenge upon receiving a request
execute the CallSpec
expect that the hostname verifier's verify method is invoked
```

Unfortunately we did not succeed in making the mock server challenge for ssl verification. We then tried to go a different route, asserting that a hostname verifier of the API client is the one we had previously set on a CallSpec. This apparently did not work as well since the client is being copied (for a good reason) when [creating a new CallSpec](https://github.com/xing/xing-android-sdk/blob/allow-hostname-verification/api-client/src/main/java/com/xing/api/RealCallSpec.java#L263-L266).

@jojahner and I are both not too deep into Android, we are looking forward to any suggestion to support these changes with a good test.

__Issue:__ none yet, I can create one if needed for discussion of the topic.

__Dependencies:__
- [x] Unit Tests
